### PR TITLE
Updated the way we save scalers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ set(libxrf_fit_HEADERS
     src/data_struct/fit_parameters.h
     src/data_struct/fit_element_map.h
     src/data_struct/params_override.h
+    src/data_struct/scan_info.h
     src/data_struct/spectra.h
     src/data_struct/spectra_line.h
     src/data_struct/spectra_volume.h

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -66,7 +66,7 @@ void help()
 	logit_s<< "--update-theta : <theta_pv_string> Update the theta dataset value using theta_pv_string as new pv string ref.\n";
     logit_s<< "--update-scalers : If scalers pv's have been changed in maps_fit_parameters_override.txt file, you can run this to just update scaler values without refitting.\n";
     logit_s<<"--quick-and-dirty : Integrate the detector range into 1 spectra.\n";
-	logit_s<< "--mem-limit <limit> : Limit the memory usage. Append M for megabytes or G for gigabytes\n";
+//	logit_s<< "--mem-limit <limit> : Limit the memory usage. Append M for megabytes or G for gigabytes\n";
     logit_s<<"--optimize-fit-override-params : <int> Integrate the 8 largest mda datasets and fit with multiple params.\n"<<
                "  1 = matrix batch fit\n  2 = batch fit without tails\n  3 = batch fit with tails\n  4 = batch fit with free E, everything else fixed \n";
     logit_s<<"--optimizer <lmfit, mpfit> : Choose which optimizer to use for --optimize-fit-override-params or matrix fit routine \n";

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -62,6 +62,7 @@ void help()
     logit_s<<"--generate-avg-h5 : Generate .h5 file which is the average of all detectors .h50 - h.53 or range specified. \n";
     logit_s<<"--add-v9layout : Generate .h5 file which has v9 layout able to open in IDL MAPS software. \n";
     logit_s<<"--add-exchange : Add exchange group into hdf5 file with normalized data.\n";
+    logit_s<< "--export-csv : Export Integrated spec, fitted, background to csv file.\n";
 	logit_s<< "--update-theta : <theta_pv_string> Update the theta dataset value using theta_pv_string as new pv string ref.\n";
     logit_s<< "--update-scalers : If scalers pv's have been changed in maps_fit_parameters_override.txt file, you can run this to just update scaler values without refitting.\n";
     logit_s<<"--quick-and-dirty : Integrate the detector range into 1 spectra.\n";
@@ -267,6 +268,12 @@ int main(int argc, char *argv[])
         analysis_job.add_exchange_layout = true;
     }
 
+    if (clp.option_exists("--export-csv"))
+    {
+        analysis_job.export_int_fitted_to_csv = true;
+    }
+    
+
     if( clp.option_exists("--streamin"))
     {
         analysis_job.is_network_source = true;
@@ -349,7 +356,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-    bool update_h5_without_fitting = analysis_job.generate_average_h5 || analysis_job.add_v9_layout || analysis_job.add_exchange_layout || analysis_job.update_theta_str.length() == 0 || analysis_job.update_scalers;
+    bool update_h5_without_fitting = analysis_job.generate_average_h5 || analysis_job.add_v9_layout || analysis_job.add_exchange_layout || analysis_job.update_theta_str.length() == 0 || analysis_job.update_scalers || analysis_job.export_int_fitted_to_csv;
     bool update_h5_fit = analysis_job.fitting_routines.size() > 0 || optimize_fit_override_params || analysis_job.stream_over_network || update_h5_without_fitting;
 
     //Check to make sure we have something to do. If not then show the help screen

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -980,10 +980,10 @@ void interate_datasets_and_update(data_struct::Analysis_Job& analysis_job)
                     data_struct::Detector* det = analysis_job.get_first_detector();
                     if (det != nullptr)
                     {
-                        std::map<std::string, data_struct::ArrayXr> scalers_map;
+                        //std::map<std::string, data_struct::ArrayXr> scalers_map;
                         io::file::MDA_IO mda_io;
-                        mda_io.generate_scaler_volume(analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, &det->fit_params_override_dict, scalers_map);
-                        io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, &det->fit_params_override_dict, &scalers_map);
+                        mda_io.load(analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, &det->fit_params_override_dict);
+                        io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, &det->fit_params_override_dict, mda_io.get_scan_info());
                     }
                 }
             }

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -977,8 +977,14 @@ void interate_datasets_and_update(data_struct::Analysis_Job& analysis_job)
                 size_t len = dataset_file.length();
                 if (len > 4 && dataset_file[len - 4] == '.' && dataset_file[len - 3] == 'm' && dataset_file[len - 2] == 'd' && dataset_file[len - 1] == 'a')
                 {
-                    data_struct::Detector *det = analysis_job.get_detector(detector_num);
-                    io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, &det->fit_params_override_dict);
+                    data_struct::Detector* det = analysis_job.get_first_detector();
+                    if (det != nullptr)
+                    {
+                        std::map<std::string, data_struct::ArrayXr> scalers_map;
+                        io::file::MDA_IO mda_io;
+                        mda_io.generate_scaler_volume(analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, scalers_map);
+                        io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, &det->fit_params_override_dict, &scalers_map);
+                    }
                 }
             }
         }

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -491,10 +491,20 @@ void process_dataset_files(data_struct::Analysis_Job* analysis_job, Callback_Fun
                 //Spectra volume data
                 data_struct::Spectra_Volume* spectra_volume = new data_struct::Spectra_Volume();
 
-                std::string str_detector_num = std::to_string(detector_num);
-                std::string full_save_path = analysis_job->dataset_directory+ DIR_END_CHAR+"img.dat"+ DIR_END_CHAR +dataset_file+".h5"+str_detector_num;
-                io::file::HDF5_IO::inst()->set_filename(full_save_path);
-
+                std::string fullpath;
+                size_t dlen = dataset_file.length();
+                if (dataset_file[dlen - 4] == '.' && dataset_file[dlen - 3] == 'm' && dataset_file[dlen - 2] == 'd' && dataset_file[dlen - 1] == 'a')
+                {
+                    std::string str_detector_num = std::to_string(detector_num);
+                    std::string full_save_path = analysis_job->dataset_directory + DIR_END_CHAR + "img.dat" + DIR_END_CHAR + dataset_file + ".h5" + str_detector_num;
+                    io::file::HDF5_IO::inst()->set_filename(full_save_path);
+                }
+                else
+                {
+                    std::string full_save_path = analysis_job->dataset_directory + DIR_END_CHAR + "img.dat" + DIR_END_CHAR + dataset_file;
+                    io::file::HDF5_IO::inst()->set_filename(full_save_path);
+                }
+                
                 bool loaded_from_analyzed_hdf5 = false;
                 //load spectra volume
                 if (false == io::load_spectra_volume(analysis_job->dataset_directory, dataset_file, detector_num, spectra_volume, &detector_struct->fit_params_override_dict, &loaded_from_analyzed_hdf5, true) )

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -982,7 +982,7 @@ void interate_datasets_and_update(data_struct::Analysis_Job& analysis_job)
                     {
                         std::map<std::string, data_struct::ArrayXr> scalers_map;
                         io::file::MDA_IO mda_io;
-                        mda_io.generate_scaler_volume(analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, scalers_map);
+                        mda_io.generate_scaler_volume(analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, &det->fit_params_override_dict, scalers_map);
                         io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, &det->fit_params_override_dict, &scalers_map);
                     }
                 }

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -978,20 +978,36 @@ void interate_datasets_and_update(data_struct::Analysis_Job& analysis_job)
                 io::file::HDF5_IO::inst()->update_theta(hdf5_dataset_name, analysis_job.update_theta_str);
             }
 
-            //update scalers table in hdf5 with new values from mda files
+            //update scalers table in hdf5
             if (analysis_job.update_scalers)
             {
-                size_t len = dataset_file.length();
-                if (len > 4 && dataset_file[len - 4] == '.' && dataset_file[len - 3] == 'm' && dataset_file[len - 2] == 'd' && dataset_file[len - 1] == 'a')
+                data_struct::Detector* det = nullptr;
+                size_t len = hdf5_dataset_name.length();
+
+                if (len > 4 && hdf5_dataset_name[len - 3] == '.' && hdf5_dataset_name[len - 2] == 'h' && hdf5_dataset_name[len - 1] == '5')
                 {
-                    data_struct::Detector* det = analysis_job.get_first_detector();
-                    if (det != nullptr)
-                    {
-                        //std::map<std::string, data_struct::ArrayXr> scalers_map;
-                        io::file::MDA_IO mda_io;
-                        mda_io.load(analysis_job.dataset_directory + "mda" + DIR_END_CHAR + dataset_file, &det->fit_params_override_dict);
-                        io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, &det->fit_params_override_dict, mda_io.get_scan_info());
-                    }
+                    det = analysis_job.get_detector(-1);
+                }
+                else if (len > 4 && hdf5_dataset_name[len - 4] == '.' && hdf5_dataset_name[len - 3] == 'h' && hdf5_dataset_name[len - 2] == '5' && hdf5_dataset_name[len - 1] == '0')
+                {
+                    det = analysis_job.get_detector(0);
+                }
+                else if (len > 4 && hdf5_dataset_name[len - 4] == '.' && hdf5_dataset_name[len - 3] == 'h' && hdf5_dataset_name[len - 2] == '5' && hdf5_dataset_name[len - 1] == '1')
+                {
+                    det = analysis_job.get_detector(1);
+                }
+                else if (len > 4 && hdf5_dataset_name[len - 4] == '.' && hdf5_dataset_name[len - 3] == 'h' && hdf5_dataset_name[len - 2] == '5' && hdf5_dataset_name[len - 1] == '2')
+                {
+                    det = analysis_job.get_detector(2);
+                }
+                else if (len > 4 && hdf5_dataset_name[len - 4] == '.' && hdf5_dataset_name[len - 3] == 'h' && hdf5_dataset_name[len - 2] == '5' && hdf5_dataset_name[len - 1] == '3')
+                {
+                    det = analysis_job.get_detector(3);
+                }
+
+                if (det != nullptr)
+                {
+                    io::file::HDF5_IO::inst()->update_scalers(hdf5_dataset_name, &det->fit_params_override_dict);
                 }
             }
         }

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -1013,6 +1013,12 @@ void interate_datasets_and_update(data_struct::Analysis_Job& analysis_job)
                 io::file::HDF5_IO::inst()->add_exchange_layout(hdf5_dataset_name);
             }
 
+            //add exchange
+            if (analysis_job.export_int_fitted_to_csv)
+            {
+                io::file::HDF5_IO::inst()->export_int_fitted_to_csv(hdf5_dataset_name);
+            }
+
             //update theta based on new PV
             if (analysis_job.update_theta_str.length() > 0)
             {

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -58,23 +58,23 @@ data_struct::Fit_Count_Dict* generate_fit_count_dict(std::unordered_map<std::str
     data_struct::Fit_Count_Dict* element_fit_counts_dict = new data_struct::Fit_Count_Dict();
     for(auto& e_itr : *elements_to_fit)
     {
-        element_fit_counts_dict->emplace(std::pair<std::string, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(e_itr.first, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> ()) );
+        element_fit_counts_dict->emplace(std::pair<std::string, data_struct::ArrayXXr >(e_itr.first, data_struct::ArrayXXr()) );
         element_fit_counts_dict->at(e_itr.first).resize(height, width);
     }
 
     if (alloc_iter_count)
     {
         //Allocate memeory to save number of fit iterations
-        element_fit_counts_dict->emplace(std::pair<std::string, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(STR_NUM_ITR, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>() ));
+        element_fit_counts_dict->emplace(std::pair<std::string, data_struct::ArrayXXr >(STR_NUM_ITR, data_struct::ArrayXXr() ));
         element_fit_counts_dict->at(STR_NUM_ITR).resize(height, width);
     }
 
 	//  TOTAL_FLUORESCENCE_YIELD
-	element_fit_counts_dict->emplace(std::pair<std::string, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(STR_TOTAL_FLUORESCENCE_YIELD, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>()));
+	element_fit_counts_dict->emplace(std::pair<std::string, data_struct::ArrayXXr >(STR_TOTAL_FLUORESCENCE_YIELD, data_struct::ArrayXXr()));
 	element_fit_counts_dict->at(STR_TOTAL_FLUORESCENCE_YIELD).resize(height, width);
 
 	//SUM_ELASTIC_INELASTIC
-	element_fit_counts_dict->emplace(std::pair<std::string, Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(STR_SUM_ELASTIC_INELASTIC_AMP , Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>()));
+	element_fit_counts_dict->emplace(std::pair<std::string, data_struct::ArrayXXr >(STR_SUM_ELASTIC_INELASTIC_AMP , data_struct::ArrayXXr()));
 	element_fit_counts_dict->at(STR_SUM_ELASTIC_INELASTIC_AMP).resize(height, width);
 
 
@@ -584,19 +584,19 @@ void find_quantifier_scalers(data_struct::Params_Override * override_params, uno
             *(pointer_arr[i]) = 0.0;
             for (auto &jitr : sscaler->scalers_to_sum)
             {
-                if(override_params->time_normalized_scalers.count(jitr.first)
-               && pv_map.count(override_params->time_normalized_scalers[jitr.first])
+                if(override_params->time_normalized_scalers.count(jitr)
+               && pv_map.count(override_params->time_normalized_scalers[jitr])
                && pv_map.count(override_params->time_scaler))
                 {
-                    real_t val = std::stof(pv_map[override_params->time_normalized_scalers[jitr.first]]);
+                    real_t val = std::stof(pv_map[override_params->time_normalized_scalers[jitr]]);
                     real_t det_time = std::stof(pv_map[override_params->time_scaler]);
                     det_time /= scaler_clock;
                     val /= det_time;
                     *(pointer_arr[i]) += val;
                 }
-                else if(override_params->scaler_pvs.count(jitr.first) && pv_map.count(override_params->scaler_pvs[jitr.first]) > 0)
+                else if(override_params->scaler_pvs.count(jitr) && pv_map.count(override_params->scaler_pvs[jitr]) > 0)
                 {
-                    *(pointer_arr[i]) += std::stof(pv_map[override_params->scaler_pvs[jitr.first]]);
+                    *(pointer_arr[i]) += std::stof(pv_map[override_params->scaler_pvs[jitr]]);
                 }
             }
         }

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -394,15 +394,22 @@ void proc_spectra(data_struct::Spectra_Volume* spectra_volume,
 
         io::file::HDF5_IO::inst()->save_element_fits(fit_routine->get_name(), element_fit_count_dict);
 
-        if(itr.first == data_struct::Fitting_Routines::GAUSS_MATRIX)
+        if(itr.first == data_struct::Fitting_Routines::GAUSS_MATRIX || itr.first == data_struct::Fitting_Routines::NNLS)
         {
             fitting::routines::Matrix_Optimized_Fit_Routine* matrix_fit = (fitting::routines::Matrix_Optimized_Fit_Routine*)fit_routine;
             io::file::HDF5_IO::inst()->save_fitted_int_spectra( fit_routine->get_name(),
 																matrix_fit->fitted_integrated_spectra(),
 																matrix_fit->energy_range(),
+																(*spectra_volume)[0][0].size());
+        }
+		if (itr.first == data_struct::Fitting_Routines::GAUSS_MATRIX)
+		{
+			fitting::routines::Matrix_Optimized_Fit_Routine* matrix_fit = (fitting::routines::Matrix_Optimized_Fit_Routine*)fit_routine;
+			io::file::HDF5_IO::inst()->save_max_10_spectra(fit_routine->get_name(),
+																matrix_fit->energy_range(),
 																matrix_fit->max_integrated_spectra(),
 																matrix_fit->max_10_integrated_spectra());
-        }
+		}
 
         delete fit_job_queue;
         element_fit_count_dict->clear();

--- a/src/core/process_whole.cpp
+++ b/src/core/process_whole.cpp
@@ -420,6 +420,7 @@ void proc_spectra(data_struct::Spectra_Volume* spectra_volume,
             io::file::HDF5_IO::inst()->save_fitted_int_spectra( fit_routine->get_name(),
 																matrix_fit->fitted_integrated_spectra(),
 																matrix_fit->energy_range(),
+                                                                matrix_fit->fitted_integrated_background(),
 																(*spectra_volume)[0][0].size());
         }
 		if (itr.first == data_struct::Fitting_Routines::GAUSS_MATRIX)

--- a/src/core/process_whole.h
+++ b/src/core/process_whole.h
@@ -156,6 +156,10 @@ DLL_EXPORT void process_dataset_files(data_struct::Analysis_Job* analysis_job);
 
 // ----------------------------------------------------------------------------
 
+void process_dataset_files_quick_and_dirty(std::string dataset_file, data_struct::Analysis_Job* analysis_job, ThreadPool& tp);
+
+// ----------------------------------------------------------------------------
+
 DLL_EXPORT bool perform_quantification(data_struct::Analysis_Job* analysis_job);
 
 // ----------------------------------------------------------------------------

--- a/src/core/process_whole.h
+++ b/src/core/process_whole.h
@@ -99,6 +99,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 using namespace std::placeholders; //for _1, _2,
 
+DLL_EXPORT typedef std::function<void(size_t, size_t)> Callback_Func_Status_Def;
+
 // ----------------------------------------------------------------------------
 
 template<typename T>
@@ -148,15 +150,16 @@ DLL_EXPORT void generate_optimal_params(data_struct::Analysis_Job* analysis_job)
 DLL_EXPORT void proc_spectra(data_struct::Spectra_Volume* spectra_volume,
                              data_struct::Detector* detector_struct,
                              ThreadPool* tp,
-                             bool save_spec_vol);
+                             bool save_spec_vol,
+                             Callback_Func_Status_Def* status_callback = nullptr);
 
 // ----------------------------------------------------------------------------
 
-DLL_EXPORT void process_dataset_files(data_struct::Analysis_Job* analysis_job);
+DLL_EXPORT void process_dataset_files(data_struct::Analysis_Job* analysis_job, Callback_Func_Status_Def* status_callback = nullptr);
 
 // ----------------------------------------------------------------------------
 
-void process_dataset_files_quick_and_dirty(std::string dataset_file, data_struct::Analysis_Job* analysis_job, ThreadPool& tp);
+void process_dataset_files_quick_and_dirty(std::string dataset_file, data_struct::Analysis_Job* analysis_job, ThreadPool& tp, Callback_Func_Status_Def* status_callback = nullptr);
 
 // ----------------------------------------------------------------------------
 

--- a/src/core/process_whole.h
+++ b/src/core/process_whole.h
@@ -165,5 +165,8 @@ DLL_EXPORT void average_quantification(std::vector<data_struct::Quantification_S
 
 // ----------------------------------------------------------------------------
 
+DLL_EXPORT void interate_datasets_and_update(data_struct::Analysis_Job& analysis_job);
+
+// ----------------------------------------------------------------------------
 
 #endif

--- a/src/data_struct/analysis_job.cpp
+++ b/src/data_struct/analysis_job.cpp
@@ -69,6 +69,7 @@ Analysis_Job::Analysis_Job()
     is_network_source = false;
     stream_over_network = false;
     update_scalers = false;
+    export_int_fitted_to_csv = false;
     command_line = "";
     theta_pv = "";
     network_source_ip = "";

--- a/src/data_struct/analysis_job.cpp
+++ b/src/data_struct/analysis_job.cpp
@@ -68,6 +68,7 @@ Analysis_Job::Analysis_Job()
     add_exchange_layout = false;
     is_network_source = false;
     stream_over_network = false;
+    update_scalers = false;
     command_line = "";
     theta_pv = "";
     network_source_ip = "";

--- a/src/data_struct/analysis_job.h
+++ b/src/data_struct/analysis_job.h
@@ -199,6 +199,8 @@ public:
 
     bool stream_over_network;
 
+    bool export_int_fitted_to_csv;
+
 	long long mem_limit;
 
 protected:

--- a/src/data_struct/analysis_job.h
+++ b/src/data_struct/analysis_job.h
@@ -185,6 +185,8 @@ public:
 
     size_t num_threads;
 
+    bool update_scalers;
+
     bool quick_and_dirty;
 
     bool generate_average_h5;

--- a/src/data_struct/element_info.cpp
+++ b/src/data_struct/element_info.cpp
@@ -320,7 +320,6 @@ void Element_Info_Map::add_element(Element_Info* element)
 {
     // set global energies pointer
     element->energies = &_energies;
-    // TODO: check if it exists
     _number_element_info_map[element->number] = element;
     _name_element_info_map[element->name] = element;
 }

--- a/src/data_struct/element_info.cpp
+++ b/src/data_struct/element_info.cpp
@@ -63,56 +63,56 @@ Element_Info::Element_Info()
 
 	real_t zero = (real_t)0.0;
 
-    xrf.emplace(std::make_pair("Ka1", zero));
-    xrf.emplace(std::make_pair("Ka2", zero));
-    xrf.emplace(std::make_pair("Kb1", zero));
-    xrf.emplace(std::make_pair("Kb2", zero));
+    xrf.emplace(std::make_pair("ka1", zero));
+    xrf.emplace(std::make_pair("ka2", zero));
+    xrf.emplace(std::make_pair("kb1", zero));
+    xrf.emplace(std::make_pair("kb2", zero));
 
-    xrf.emplace(std::make_pair("La1", zero));
-    xrf.emplace(std::make_pair("La2", zero));
-    xrf.emplace(std::make_pair("Lb1", zero));
-    xrf.emplace(std::make_pair("Lb2", zero));
-    xrf.emplace(std::make_pair("Lb3", zero));
-    xrf.emplace(std::make_pair("Lb4", zero));
-    xrf.emplace(std::make_pair("Lb5", zero));
+    xrf.emplace(std::make_pair("la1", zero));
+    xrf.emplace(std::make_pair("la2", zero));
+    xrf.emplace(std::make_pair("lb1", zero));
+    xrf.emplace(std::make_pair("lb2", zero));
+    xrf.emplace(std::make_pair("lb3", zero));
+    xrf.emplace(std::make_pair("lb4", zero));
+    xrf.emplace(std::make_pair("lb5", zero));
 
-    xrf.emplace(std::make_pair("Lg1", zero));
-    xrf.emplace(std::make_pair("Lg2", zero));
-    xrf.emplace(std::make_pair("Lg3", zero));
-    xrf.emplace(std::make_pair("Lg4", zero));
-    xrf.emplace(std::make_pair("Ll", zero));
-    xrf.emplace(std::make_pair("Ln", zero));
+    xrf.emplace(std::make_pair("lg1", zero));
+    xrf.emplace(std::make_pair("lg2", zero));
+    xrf.emplace(std::make_pair("lg3", zero));
+    xrf.emplace(std::make_pair("lg4", zero));
+    xrf.emplace(std::make_pair("ll", zero));
+    xrf.emplace(std::make_pair("ln", zero));
 
-    xrf.emplace(std::make_pair("Ma1", zero));
-    xrf.emplace(std::make_pair("Ma2", zero));
-    xrf.emplace(std::make_pair("Mb", zero));
-    xrf.emplace(std::make_pair("Mg", zero));
+    xrf.emplace(std::make_pair("ma1", zero));
+    xrf.emplace(std::make_pair("ma2", zero));
+    xrf.emplace(std::make_pair("mb", zero));
+    xrf.emplace(std::make_pair("mg", zero));
 
 
-    xrf_abs_yield.emplace(std::make_pair("Ka1", zero));
-    xrf_abs_yield.emplace(std::make_pair("Ka2", zero));
-    xrf_abs_yield.emplace(std::make_pair("Kb1", zero));
-    xrf_abs_yield.emplace(std::make_pair("Kb2", zero));
+    xrf_abs_yield.emplace(std::make_pair("ka1", zero));
+    xrf_abs_yield.emplace(std::make_pair("ka2", zero));
+    xrf_abs_yield.emplace(std::make_pair("kb1", zero));
+    xrf_abs_yield.emplace(std::make_pair("kb2", zero));
 
-    xrf_abs_yield.emplace(std::make_pair("La1", zero));
-    xrf_abs_yield.emplace(std::make_pair("La2", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lb1", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lb2", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lb3", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lb4", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lb5", zero));
+    xrf_abs_yield.emplace(std::make_pair("la1", zero));
+    xrf_abs_yield.emplace(std::make_pair("la2", zero));
+    xrf_abs_yield.emplace(std::make_pair("lb1", zero));
+    xrf_abs_yield.emplace(std::make_pair("lb2", zero));
+    xrf_abs_yield.emplace(std::make_pair("lb3", zero));
+    xrf_abs_yield.emplace(std::make_pair("lb4", zero));
+    xrf_abs_yield.emplace(std::make_pair("lb5", zero));
 
-    xrf_abs_yield.emplace(std::make_pair("Lg1", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lg2", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lg3", zero));
-    xrf_abs_yield.emplace(std::make_pair("Lg4", zero));
-    xrf_abs_yield.emplace(std::make_pair("Ll", zero));
-    xrf_abs_yield.emplace(std::make_pair("Ln", zero));
+    xrf_abs_yield.emplace(std::make_pair("lg1", zero));
+    xrf_abs_yield.emplace(std::make_pair("lg2", zero));
+    xrf_abs_yield.emplace(std::make_pair("lg3", zero));
+    xrf_abs_yield.emplace(std::make_pair("lg4", zero));
+    xrf_abs_yield.emplace(std::make_pair("ll", zero));
+    xrf_abs_yield.emplace(std::make_pair("ln", zero));
 
-    xrf_abs_yield.emplace(std::make_pair("Ma1", zero));
-    xrf_abs_yield.emplace(std::make_pair("Ma2", zero));
-    xrf_abs_yield.emplace(std::make_pair("Mb", zero));
-    xrf_abs_yield.emplace(std::make_pair("Mg", zero));
+    xrf_abs_yield.emplace(std::make_pair("ma1", zero));
+    xrf_abs_yield.emplace(std::make_pair("ma2", zero));
+    xrf_abs_yield.emplace(std::make_pair("mb", zero));
+    xrf_abs_yield.emplace(std::make_pair("mg", zero));
 
     yieldD.emplace(std::make_pair("k", zero));
     yieldD.emplace(std::make_pair("l1", zero));

--- a/src/data_struct/fit_element_map.cpp
+++ b/src/data_struct/fit_element_map.cpp
@@ -240,7 +240,7 @@ void Fit_Element_Map::set_custom_multiply_ratio(unsigned int idx, real_t multi)
 {
     if (idx > 0 && idx < _energy_ratio_custom_multipliers.size())
     {
-        _energy_ratio_custom_multipliers[idx] = multi;
+        _energy_ratio_custom_multipliers[idx] *= multi;
     }
 }
 

--- a/src/data_struct/fit_element_map.h
+++ b/src/data_struct/fit_element_map.h
@@ -150,7 +150,7 @@ public:
 
     const std::string& full_name() const { return _full_name; }
 
-    const std::string symbol() const { return _element_info==nullptr?"":_element_info->name; }
+    const std::string symbol() const { return _element_info==nullptr?"NULLPTR":_element_info->name; }
 
     int Z() const {return _element_info==nullptr? -1:_element_info->number;}
 

--- a/src/data_struct/fit_parameters.h
+++ b/src/data_struct/fit_parameters.h
@@ -67,7 +67,9 @@ enum class E_Bound_Type {NOT_INIT=0, FIXED=1, LIMITED_LO_HI=2, LIMITED_LO=3, LIM
 
 //-----------------------------------------------------------------------------
 
-typedef std::unordered_map<std::string, Eigen::Array<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > Fit_Count_Dict;
+typedef Eigen::Array<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> ArrayXXr;
+
+typedef std::unordered_map<std::string, ArrayXXr > Fit_Count_Dict;
 
 /**
 * @brief The Range struct to determine size of spectra we want to fit or model

--- a/src/data_struct/params_override.h
+++ b/src/data_struct/params_override.h
@@ -66,8 +66,8 @@ using namespace std;
 struct Summed_Scaler
 {
     string scaler_name;
-    //  name    mda_idx
-    map<string, int> scalers_to_sum;
+    //  name    
+    std::vector<string> scalers_to_sum;
     bool normalize_by_time;
 };
 
@@ -138,9 +138,8 @@ public:
     Fit_Element_Map_Dict elements_to_fit;
     string time_scaler;
     string time_scaler_clock;
-    map< string, string > time_normalized_scalers;
     string detector_element;
-    map< string, string > scaler_pvs;
+    
     real_t si_escape_factor;
     real_t ge_escape_factor;
     bool si_escape_enabled;
@@ -164,6 +163,8 @@ public:
 
     string theta_pv;
 
+    map< string, string > scaler_pvs;
+    map< string, string > time_normalized_scalers;
     list<struct Summed_Scaler> summed_scalers;
 
     real_t sr_current;

--- a/src/data_struct/params_override.h
+++ b/src/data_struct/params_override.h
@@ -167,6 +167,10 @@ public:
     map< string, string > time_normalized_scalers;
     list<struct Summed_Scaler> summed_scalers;
 
+    vector<string> branching_family_L;
+    vector<string> branching_ratio_L;
+    vector<string> branching_ratio_K;
+
     real_t sr_current;
     real_t US_IC;
     real_t DS_IC;

--- a/src/data_struct/params_override.h
+++ b/src/data_struct/params_override.h
@@ -68,6 +68,14 @@ struct Summed_Scaler
   bool normalize_by_time;
 };
 
+struct Extra_PV
+{
+    std::string name;
+    std::string description;
+    std::string value;
+    std::string unit;
+};
+
 //-----------------------------------------------------------------------------
 /**
  * @brief The Params_Override struct

--- a/src/data_struct/params_override.h
+++ b/src/data_struct/params_override.h
@@ -60,22 +60,18 @@ namespace data_struct
 
 using namespace std;
 
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
 struct Summed_Scaler
 {
-  string scaler_name;
-  //  name    mda_idx
-  map<string, int> scalers_to_sum;
-  bool normalize_by_time;
+    string scaler_name;
+    //  name    mda_idx
+    map<string, int> scalers_to_sum;
+    bool normalize_by_time;
 };
 
-struct Extra_PV
-{
-    std::string name;
-    std::string description;
-    std::string value;
-    std::string unit;
-};
-
+//-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 /**
  * @brief The Params_Override struct

--- a/src/data_struct/scan_info.h
+++ b/src/data_struct/scan_info.h
@@ -1,0 +1,128 @@
+/***
+-Copyright (c) 2016, UChicago Argonne, LLC. All rights reserved.
+-
+-Copyright 2016. UChicago Argonne, LLC. This software was produced
+-under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+-Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+-U.S. Department of Energy. The U.S. Government has rights to use,
+-reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+-UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+-ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+-modified to produce derivative works, such modified software should
+-be clearly marked, so as not to confuse it with the version available
+-from ANL.
+-
+-Additionally, redistribution and use in source and binary forms, with
+-or without modification, are permitted provided that the following
+-conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright
+-      notice, this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright
+-      notice, this list of conditions and the following disclaimer in
+-      the documentation and/or other materials provided with the
+-      distribution.
+-
+-    * Neither the name of UChicago Argonne, LLC, Argonne National
+-      Laboratory, ANL, the U.S. Government, nor the names of its
+-      contributors may be used to endorse or promote products derived
+-      from this software without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+-Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+-ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGE.
+-***/
+
+#ifndef SCAN_INFO_H
+#define SCAN_INFO_H
+
+
+#include <map>
+#include <string>
+#include <vector>
+#include "core/defines.h"
+
+#include <Eigen/core>
+
+namespace data_struct
+{
+
+using namespace std;
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+struct Extra_PV
+{
+    string name;
+    string description;
+    string value;
+    string unit;
+};
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+struct Scaler_Map
+{
+    string name;
+    string unit;
+    Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> values;
+};
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+struct Scan_Meta_Info
+{
+    string name;
+    string scan_time_stamp;
+    vector<real_t> x_axis;
+    vector<real_t> y_axis;
+    int requested_cols;
+    int requested_rows;
+    real_t theta;
+    
+};
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+/**
+ * @brief The Params_Override struct
+ */
+class DLL_EXPORT Scan_Info
+{
+
+public:
+
+    Scan_Info()
+    {
+        
+    }
+    
+    ~Scan_Info()
+    {
+        
+    }
+
+    Scan_Meta_Info meta_info;
+    vector<Scaler_Map> scaler_maps;
+    vector<Extra_PV> extra_pvs;
+    bool has_netcdf; 
+};
+
+//-----------------------------------------------------------------------------
+
+} //namespace data_struct
+
+#endif // Scan_Info_H

--- a/src/data_struct/scan_info.h
+++ b/src/data_struct/scan_info.h
@@ -1,5 +1,5 @@
 /***
--Copyright (c) 2016, UChicago Argonne, LLC. All rights reserved.
+-Copyright (c) 2020, UChicago Argonne, LLC. All rights reserved.
 -
 -Copyright 2016. UChicago Argonne, LLC. This software was produced
 -under U.S. Government contract DE-AC02-06CH11357 for Argonne National
@@ -52,7 +52,7 @@
 #include <vector>
 #include "core/defines.h"
 
-#include <Eigen/core>
+#include "fit_parameters.h" // for ArrayXXr 
 
 namespace data_struct
 {
@@ -77,7 +77,7 @@ struct Scaler_Map
 {
     string name;
     string unit;
-    Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> values;
+    ArrayXXr values;
 };
 
 //-----------------------------------------------------------------------------

--- a/src/data_struct/spectra_volume.cpp
+++ b/src/data_struct/spectra_volume.cpp
@@ -113,27 +113,43 @@ void Spectra_Volume::recalc_elapsed_livetime()
 
 }
 
-void Spectra_Volume::generate_scaler_maps(Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * elt_map,
-                                          Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * ert_map,
-                                          Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * in_cnt_map,
-                                          Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * out_cnt_map)
+void Spectra_Volume::generate_scaler_maps(vector<Scaler_Map> *scaler_maps)
 {
-    elt_map->resize(_data_vol.size(), _data_vol[0].size());
-    ert_map->resize(_data_vol.size(), _data_vol[0].size());
-    in_cnt_map->resize(_data_vol.size(), _data_vol[0].size());
-    out_cnt_map->resize(_data_vol.size(), _data_vol[0].size());
-
-    for(size_t i = 0; i < _data_vol.size(); i++)
+    if (scaler_maps != nullptr)
     {
-        for(size_t j = 0; j < _data_vol[0].size(); j++)
-        {
-            (*elt_map)(i,j) = _data_vol[i][j].elapsed_livetime();
-            (*ert_map)(i,j) = _data_vol[i][j].elapsed_realtime();
-            (*in_cnt_map)(i,j) = _data_vol[i][j].input_counts();
-            (*out_cnt_map)(i,j) = _data_vol[i][j].output_counts();
-        }
-    }
 
+        data_struct::Scaler_Map elt_map, ert_map, in_cnt_map, out_cnt_map;
+
+        elt_map.name = "ELT";
+        ert_map.name = "ERT";
+        in_cnt_map.name = "INCNT";
+        out_cnt_map.name = "OUTCNT";
+        elt_map.unit = "seconds";
+        ert_map.unit = "seconds";
+        in_cnt_map.unit = "cts/s";
+        out_cnt_map.unit = "cts/s";
+
+        elt_map.values.resize(_data_vol.size(), _data_vol[0].size());
+        ert_map.values.resize(_data_vol.size(), _data_vol[0].size());
+        in_cnt_map.values.resize(_data_vol.size(), _data_vol[0].size());
+        out_cnt_map.values.resize(_data_vol.size(), _data_vol[0].size());
+
+        for (size_t i = 0; i < _data_vol.size(); i++)
+        {
+            for (size_t j = 0; j < _data_vol[0].size(); j++)
+            {
+                elt_map.values(i, j) = _data_vol[i][j].elapsed_livetime();
+                ert_map.values(i, j) = _data_vol[i][j].elapsed_realtime();
+                in_cnt_map.values(i, j) = _data_vol[i][j].input_counts();
+                out_cnt_map.values(i, j) = _data_vol[i][j].output_counts();
+            }
+        }
+
+        scaler_maps->push_back(elt_map);
+        scaler_maps->push_back(ert_map);
+        scaler_maps->push_back(in_cnt_map);
+        scaler_maps->push_back(out_cnt_map);
+    }
 }
 
 } //namespace data_struct

--- a/src/data_struct/spectra_volume.h
+++ b/src/data_struct/spectra_volume.h
@@ -51,6 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define SPECTRAVOLUME_H
 
 #include "data_struct/spectra_line.h"
+#include "scan_info.h"
 
 namespace data_struct
 {
@@ -73,10 +74,7 @@ public:
 
     Spectra integrate();
 
-    void generate_scaler_maps(Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * elt_map,
-                              Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * ert_map,
-                              Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * in_cnt_map,
-                              Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * out_cnt_map);
+    void generate_scaler_maps(vector<Scaler_Map>* scaler_maps);
 
 	size_t cols() const { if (_data_vol.size() > 0) return _data_vol[0].size(); else return 0; }
 

--- a/src/fitting/models/base_model.h
+++ b/src/fitting/models/base_model.h
@@ -125,6 +125,8 @@ public:
 
     virtual const ArrayXr compton_peak(const Fit_Parameters * const fitp, const ArrayXr& ev, real_t gain) const = 0;
 
+    virtual const ArrayXr escape_peak(const Fit_Parameters* const fitp, const ArrayXr& ev, real_t gain) const = 0;
+
     virtual void reset_to_default_fit_params() = 0;
 
     virtual void update_fit_params_values(Fit_Parameters *fit_params) = 0;

--- a/src/fitting/models/gaussian_model.cpp
+++ b/src/fitting/models/gaussian_model.cpp
@@ -325,33 +325,7 @@ const Spectra Gaussian_Model::model_spectrum(const Fit_Parameters * const fit_pa
     agr_spectra += elastic_peak(fit_params, ev, fit_params->at(STR_ENERGY_SLOPE).value);
     agr_spectra += compton_peak(fit_params, ev, fit_params->at(STR_ENERGY_SLOPE).value);
 
-
-/*
-    //escape
-    //if (np.sum(np.abs(pall[keywords.added_params[1:4]])) >= 0.0)
-    {
-        // si escape
-        if (fit_params->at(STR_SI_ESCAPE).value > 0.0)
-        //if (pall[keywords.added_params[1]] > 0.0)
-        {
-            real_t escape_E = (real_t)1.73998;
-            for (size_t i=0; i<ev.size(); i++)
-            {
-                if( ev[i] > (escape_E+ev[0]) )
-                {
-                    escape_factor = pall[keywords.added_params[1]] + pall[keywords.added_params[3]] * ev;
-
-                    for ( int ii=0; ii<len(wo[0]); ii++ )
-                    {
-                        fit_counts.escape[ii] = counts[wo[0][ii]] * std::max(np.append(escape_factor[wo[0][ii]], 0.0));
-                    }
-                }
-            }
-        }
-        *(agr_spectra.buffer()) += fit_counts.escape;
-    }
-
-*/
+ //   agr_spectra += escape_peak(fit_params, ev, fit_params->at(STR_ENERGY_SLOPE).value);
 
     return agr_spectra;
 }
@@ -590,6 +564,37 @@ const ArrayXr Gaussian_Model::compton_peak(const Fit_Parameters * const fitp, co
 }
 
 // ----------------------------------------------------------------------------
+
+const ArrayXr Gaussian_Model::escape_peak(const Fit_Parameters* const fitp, const ArrayXr& ev, real_t  gain) const
+{
+    ArrayXr counts(ev.size());
+    counts.setZero();
+    /*
+    //escape
+    //if (np.sum(np.abs(pall[keywords.added_params[1:4]])) >= 0.0)
+    {
+        // si escape
+        if (fit_params->at(STR_SI_ESCAPE).value > 0.0)
+            //if (pall[keywords.added_params[1]] > 0.0)
+        {
+            real_t escape_E = (real_t)1.73998;
+            for (size_t i = 0; i < ev.size(); i++)
+            {
+                if (ev[i] > (escape_E + ev[0]))
+                {
+                    escape_factor = pall[keywords.added_params[1]] + pall[keywords.added_params[3]] * ev;
+
+                    for (int ii = 0; ii < len(wo[0]); ii++)
+                    {
+                        fit_counts.escape[ii] = counts[wo[0][ii]] * std::max(np.append(escape_factor[wo[0][ii]], 0.0));
+                    }
+                }
+            }
+        }
+    }
+    */
+    return counts;
+}
 
 } //namespace models
 } //namespace fitting

--- a/src/fitting/models/gaussian_model.h
+++ b/src/fitting/models/gaussian_model.h
@@ -114,6 +114,8 @@ public:
 
     virtual const ArrayXr compton_peak(const Fit_Parameters * const fitp, const ArrayXr& ev, real_t gain) const;
 
+    virtual const ArrayXr Gaussian_Model::escape_peak(const Fit_Parameters* const fitp, const ArrayXr& ev, real_t  gain) const;
+
     virtual void reset_to_default_fit_params() { _fit_parameters = _generate_default_fit_parameters(); }
 
     virtual void update_fit_params_values(Fit_Parameters *fit_params) { _fit_parameters.update_values(fit_params); }

--- a/src/fitting/models/gaussian_model.h
+++ b/src/fitting/models/gaussian_model.h
@@ -114,7 +114,7 @@ public:
 
     virtual const ArrayXr compton_peak(const Fit_Parameters * const fitp, const ArrayXr& ev, real_t gain) const;
 
-    virtual const ArrayXr Gaussian_Model::escape_peak(const Fit_Parameters* const fitp, const ArrayXr& ev, real_t  gain) const;
+    virtual const ArrayXr escape_peak(const Fit_Parameters* const fitp, const ArrayXr& ev, real_t  gain) const;
 
     virtual void reset_to_default_fit_params() { _fit_parameters = _generate_default_fit_parameters(); }
 

--- a/src/fitting/optimizers/lmfit_optimizer.cpp
+++ b/src/fitting/optimizers/lmfit_optimizer.cpp
@@ -228,12 +228,13 @@ void LMFit_Optimizer::minimize(Fit_Parameters *fit_params,
 void LMFit_Optimizer::minimize_func(Fit_Parameters *fit_params,
                                     const Spectra * const spectra,
                                     const Range energy_range,
+                                    const ArrayXr *background,
                                     Gen_Func_Def gen_func)
 {
 
     Gen_User_Data ud;
 
-    fill_gen_user_data(ud, fit_params, spectra, energy_range, gen_func);
+    fill_gen_user_data(ud, fit_params, spectra, energy_range, background, gen_func);
 
     std::vector<real_t> fitp_arr = fit_params->to_array();
     std::vector<real_t> perror(fitp_arr.size());

--- a/src/fitting/optimizers/lmfit_optimizer.h
+++ b/src/fitting/optimizers/lmfit_optimizer.h
@@ -80,6 +80,7 @@ public:
     virtual void minimize_func(Fit_Parameters *fit_params,
                                const Spectra * const spectra,
                                const Range energy_range,
+                               const ArrayXr* background,
                                Gen_Func_Def gen_func);
 
     virtual void minimize_quantification(Fit_Parameters *fit_params,

--- a/src/fitting/optimizers/mpfit_optimizer.cpp
+++ b/src/fitting/optimizers/mpfit_optimizer.cpp
@@ -359,11 +359,12 @@ void MPFit_Optimizer::minimize(Fit_Parameters *fit_params,
 void MPFit_Optimizer::minimize_func(Fit_Parameters *fit_params,
                                     const Spectra * const spectra,
                                     const Range energy_range,
+                                    const ArrayXr* background,
 									Gen_Func_Def gen_func)
 {
     Gen_User_Data ud;
 
-    fill_gen_user_data(ud, fit_params, spectra, energy_range, gen_func);
+    fill_gen_user_data(ud, fit_params, spectra, energy_range, background, gen_func);
     
 
     std::vector<real_t> fitp_arr = fit_params->to_array();

--- a/src/fitting/optimizers/mpfit_optimizer.h
+++ b/src/fitting/optimizers/mpfit_optimizer.h
@@ -78,6 +78,7 @@ public:
     virtual void minimize_func(Fit_Parameters *fit_params,
                                const Spectra * const spectra,
                                const Range energy_range,
+                               const ArrayXr* background,
                                Gen_Func_Def gen_func);
 
     virtual void minimize_quantification(Fit_Parameters *fit_params,

--- a/src/fitting/optimizers/optimizer.cpp
+++ b/src/fitting/optimizers/optimizer.cpp
@@ -102,6 +102,7 @@ namespace optimizers
                             Fit_Parameters *fit_params,
                             const Spectra * const spectra,
                             const Range energy_range,
+                            const ArrayXr* background,
                             Gen_Func_Def gen_func)
 	{
 		ud.func = gen_func;
@@ -118,10 +119,10 @@ namespace optimizers
 		weights = Eigen::abs(weights);
 		weights /= weights.maxCoeff();
 		ud.weights = weights.segment(energy_range.min, energy_range.count());
-
+        /*
         ArrayXr background(spectra->size());
         background.setZero(spectra->size());
-
+        
         if(fit_params->contains(STR_SNIP_WIDTH))
         {
             real_t spectral_binning = 0.0;
@@ -134,9 +135,10 @@ namespace optimizers
                                          energy_range.min,
                                          energy_range.max);
         }
-
-		ud.spectra_background = background.segment(energy_range.min, energy_range.count());
+        */
+		ud.spectra_background = background->segment(energy_range.min, energy_range.count());
         ud.spectra_background = ud.spectra_background.unaryExpr([](real_t v) { return std::isfinite(v) ? v : (real_t)0.0; });
+        
 		ud.spectra_model.resize(energy_range.count());
 	}
 

--- a/src/fitting/optimizers/optimizer.h
+++ b/src/fitting/optimizers/optimizer.h
@@ -119,6 +119,7 @@ void fill_gen_user_data(Gen_User_Data &ud,
                         Fit_Parameters *fit_params,
                         const Spectra * const spectra,
                         const Range energy_range,
+                        const ArrayXr* background,
                         Gen_Func_Def gen_func);
 
 void update_background_user_data(User_Data *ud);
@@ -142,6 +143,7 @@ public:
     virtual void minimize_func(Fit_Parameters *fit_params,
                                const Spectra * const spectra,
                                const Range energy_range,
+                               const ArrayXr* background,
                                Gen_Func_Def gen_func) = 0;
 
 

--- a/src/fitting/routines/matrix_optimized_fit_routine.h
+++ b/src/fitting/routines/matrix_optimized_fit_routine.h
@@ -99,14 +99,16 @@ protected:
                                                             const Fit_Element_Map_Dict * const elements_to_fit,
                                                             struct Range energy_range);
 
+	data_struct::Spectra _integrated_fitted_spectra;
+	data_struct::Spectra _max_channels_spectra;
+	data_struct::Spectra _max_10_channels_spectra;
+
 private:
 
     unordered_map<string, Spectra> _element_models;
 
     static std::mutex _int_spec_mutex;
-    data_struct::Spectra _integrated_fitted_spectra;
-	data_struct::Spectra _max_channels_spectra;
-	data_struct::Spectra _max_10_channels_spectra;
+
 };
 
 } //namespace routines

--- a/src/fitting/routines/matrix_optimized_fit_routine.h
+++ b/src/fitting/routines/matrix_optimized_fit_routine.h
@@ -89,6 +89,8 @@ public:
 
     const Spectra& fitted_integrated_spectra() {return _integrated_fitted_spectra;}
 
+    const Spectra& fitted_integrated_background() { return _integrated_background; }
+
 	const Spectra& max_integrated_spectra() { return _max_channels_spectra; }
 
 	const Spectra& max_10_integrated_spectra() { return _max_10_channels_spectra; }
@@ -100,6 +102,7 @@ protected:
                                                             struct Range energy_range);
 
 	data_struct::Spectra _integrated_fitted_spectra;
+    data_struct::Spectra _integrated_background;
 	data_struct::Spectra _max_channels_spectra;
 	data_struct::Spectra _max_10_channels_spectra;
 

--- a/src/fitting/routines/nnls_fit_routine.h
+++ b/src/fitting/routines/nnls_fit_routine.h
@@ -90,6 +90,8 @@ private:
 
     size_t _max_iter;
 
+	static std::mutex _int_spec_mutex;
+
     Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic> _fitmatrix;
 
     std::unordered_map<std::string, int> _element_row_index;

--- a/src/io/file/aps/aps_fit_params_import.cpp
+++ b/src/io/file/aps/aps_fit_params_import.cpp
@@ -365,12 +365,43 @@ bool APS_Fit_Params_Import::load(std::string path,
                     if(params_override->elements_to_fit.count(element_symb) > 0)
                     {
                         fit_map = params_override->elements_to_fit[element_symb];
-                        for (unsigned int i = 0; i<cnt; i++)
+                        if (cnt == 3) // family
                         {
                             float factor = 1.0;
+
+                            // 1
                             std::getline(strstream, str_value, ',');
                             factor = std::stof(str_value);
-                            fit_map->set_custom_multiply_ratio(i, factor);
+                            fit_map->set_custom_multiply_ratio(4, factor);
+                            fit_map->set_custom_multiply_ratio(5, factor);
+                            fit_map->set_custom_multiply_ratio(7, factor);
+                            fit_map->set_custom_multiply_ratio(8, factor);
+                            fit_map->set_custom_multiply_ratio(9, factor);
+
+                            // 2
+                            std::getline(strstream, str_value, ',');
+                            factor = std::stof(str_value);
+                            fit_map->set_custom_multiply_ratio(2, factor);
+                            fit_map->set_custom_multiply_ratio(6, factor);
+                            fit_map->set_custom_multiply_ratio(11, factor);
+
+                            //3
+                            std::getline(strstream, str_value, ',');
+                            factor = std::stof(str_value);
+                            fit_map->set_custom_multiply_ratio(0, factor);
+                            fit_map->set_custom_multiply_ratio(1, factor);
+                            fit_map->set_custom_multiply_ratio(3, factor);
+                            fit_map->set_custom_multiply_ratio(10, factor);
+                        }
+                        else // ratio's
+                        {
+                            for (unsigned int i = 0; i < cnt; i++)
+                            {
+                                float factor = 1.0;
+                                std::getline(strstream, str_value, ',');
+                                factor = std::stof(str_value);
+                                fit_map->set_custom_multiply_ratio(i, factor);
+                            }
                         }
                     }
                 }

--- a/src/io/file/aps/aps_fit_params_import.cpp
+++ b/src/io/file/aps/aps_fit_params_import.cpp
@@ -189,6 +189,7 @@ bool APS_Fit_Params_Import::load(std::string path,
             {
                 std::istringstream strstream(line);
                 std::getline(strstream, tag, ':');
+                //tag.erase(std::remove_if(tag.begin(), tag.end(), ::isspace), tag.end());
                 //logD<<"tag : "<<tag<<"\n";
                 if (tag == "VERSION" || tag == "DATE")
                 {
@@ -806,7 +807,7 @@ bool APS_Fit_Params_Import::save(std::string path,
     {
         out_stream << "   This file will override default fit settings for the maps program for a 3 element detector remove : removeme_ * elementdetector_to make it work. \n";
         out_stream << "   NOTE : the filename MUST be maps_fit_parameters_override.txt\n";
-        out_stream << "VERSION : 5.00000\n";
+        out_stream << "VERSION: 5.00000\n";
         out_stream << "DATE: \n";
         out_stream << "   put below the number of detectors that were used to acquire spectra. IMPORTANT: \n";
         out_stream << "   this MUST come after VERSION, and before all other options!\n";
@@ -853,7 +854,7 @@ bool APS_Fit_Params_Import::save(std::string path,
         out_stream << "    energy dependence of the energy resolution\n";
         out_stream << "FWHM_FANOPRIME: " << params_override->fit_params.at(STR_FWHM_FANOPRIME).value << "\n";
         out_stream << "    incident energy\n";
-        out_stream << "COHERENT_SCT_ENERGY: : " << params_override->fit_params.at(STR_COHERENT_SCT_ENERGY).value << "\n";
+        out_stream << "COHERENT_SCT_ENERGY: " << params_override->fit_params.at(STR_COHERENT_SCT_ENERGY).value << "\n";
         out_stream << "    upper contstraint for the incident energy\n";
         out_stream << "COHERENT_SCT_ENERGY_MAX: " << params_override->fit_params.at(STR_COHERENT_SCT_ENERGY).max_val << "\n";
         out_stream << "    lower contstraint for the incident energy\n";

--- a/src/io/file/aps/aps_fit_params_import.cpp
+++ b/src/io/file/aps/aps_fit_params_import.cpp
@@ -709,7 +709,7 @@ bool APS_Fit_Params_Import::load(std::string path,
                         scaler_name.erase(std::remove(scaler_name.begin(), scaler_name.end(), ' '), scaler_name.end());
                         last_scaler = scaler_name;
                         // add scaler name and set mda_idx to -1, we will search for the index later and unpdate
-                        s_scaler.scalers_to_sum[scaler_name]= -1;
+                        s_scaler.scalers_to_sum.push_back(scaler_name);
                         std::getline(strstream, scaler_name, ',');
                     }
                     params_override->summed_scalers.push_back(s_scaler);
@@ -735,7 +735,7 @@ bool APS_Fit_Params_Import::load(std::string path,
                         scaler_name.erase(std::remove(scaler_name.begin(), scaler_name.end(), ' '), scaler_name.end());
                         last_scaler = scaler_name;
                         // add scaler name and set mda_idx to -1, we will search for the index later and unpdate
-                        s_scaler.scalers_to_sum[scaler_name] = -1;
+                        s_scaler.scalers_to_sum.push_back(scaler_name);
                         std::getline(strstream, scaler_name, ',');
                     }
                     params_override->summed_scalers.push_back(s_scaler);

--- a/src/io/file/aps/aps_fit_params_import.cpp
+++ b/src/io/file/aps/aps_fit_params_import.cpp
@@ -340,14 +340,17 @@ bool APS_Fit_Params_Import::load(std::string path,
 
                     if (tag == "BRANCHING_FAMILY_ADJUSTMENT_L")
                     {
+                        params_override->branching_family_L.push_back(line);
                         cnt = 3;
                     }
                     else if (tag == "BRANCHING_RATIO_ADJUSTMENT_K")
                     {
+                        params_override->branching_ratio_K.push_back(line);
                         cnt = 4;
                     }
                     else if (tag == "BRANCHING_RATIO_ADJUSTMENT_L")
                     {
+                        params_override->branching_ratio_L.push_back(line);
                         cnt = 12;
                     }
 
@@ -780,7 +783,206 @@ bool APS_Fit_Params_Import::save(std::string path,
                                  Params_Override *params_override)
 {
 
+    /*
+    else if (tag == "AIRPATH")
 
+    else if (tag == "TAIL_FRACTION_ADJUST_SI")
+
+    else if (tag == "TAIL_WIDTH_ADJUST_SI")
+    */
+
+
+    if (params_override == nullptr)
+    {
+        logE << "No parameters to save in " << path << "\n";
+        return false;
+    }
+
+    std::ofstream out_stream(path);
+
+    logI << path << "\n";
+
+    if (out_stream.is_open())
+    {
+        out_stream << "   This file will override default fit settings for the maps program for a 3 element detector remove : removeme_ * elementdetector_to make it work. \n";
+        out_stream << "   NOTE : the filename MUST be maps_fit_parameters_override.txt\n";
+        out_stream << "VERSION : 5.00000\n";
+        out_stream << "DATE: \n";
+        out_stream << "   put below the number of detectors that were used to acquire spectra. IMPORTANT: \n";
+        out_stream << "   this MUST come after VERSION, and before all other options!\n";
+        out_stream << "DETECTOR_ELEMENTS:       1\n";
+        out_stream << "   give this file an internal name, whatever you like\n";
+        out_stream << "IDENTIFYING_NAME_[WHATEVERE_YOU_LIKE]:automatic\n";
+        out_stream << "   list the elements that you want to be fit. For K lines, just use the element\n";
+        out_stream << "   name, for L lines add _L, e.g., Au_L, for M lines add _M\n";
+        out_stream << "ELEMENTS_TO_FIT: ";
+        for (const auto& itr : params_override->elements_to_fit)
+        {
+            // if not pileup
+            if (itr.second->pileup_element() == nullptr && (itr.first != "COHERENT_SCT_AMPLITUDE" || itr.first != "COMPTON_AMPLITUDE"))
+            {
+                out_stream << itr.first << " , ";
+            }
+        }
+        out_stream << "\n";
+        out_stream << "   list the element combinations you want to fit for pileup, e.g., Si_Si, Si_Si_Si, Si_Cl, etc\n";
+        out_stream << "ELEMENTS_WITH_PILEUP: ";
+        for (const auto& itr : params_override->elements_to_fit)
+        {
+            // if not pileup
+            if (itr.second->pileup_element() != nullptr)
+            {
+                out_stream << itr.first << " , ";
+            }
+        }
+        out_stream << "\n";
+        out_stream << "   offset of energy calibration, in kev\n";
+        out_stream << "CAL_OFFSET_[E_OFFSET]:   "<< params_override->fit_params.at(STR_ENERGY_OFFSET).value <<"\n";
+        out_stream << "CAL_OFFSET_[E_OFFSET]_MIN:   "<< params_override->fit_params.at(STR_ENERGY_OFFSET).min_val <<"\n";
+        out_stream << "CAL_OFFSET_[E_OFFSET]_MAX:   "<< params_override->fit_params.at(STR_ENERGY_OFFSET).max_val <<"\n";
+        out_stream << "   slope of energy calibration, in leV / channel\n";
+        out_stream << "CAL_SLOPE_[E_LINEAR]:   "<< params_override->fit_params.at(STR_ENERGY_SLOPE).value <<"\n";
+        out_stream << "CAL_SLOPE_[E_LINEAR]_MIN:   "<< params_override->fit_params.at(STR_ENERGY_SLOPE).min_val <<"\n";
+        out_stream << "CAL_SLOPE_[E_LINEAR]_MAX:   "<< params_override->fit_params.at(STR_ENERGY_SLOPE).max_val <<"\n";
+        out_stream << "   quadratic correction for energy calibration, unless you know exactly what you are doing, please leave it at 0.\n";
+        out_stream << "CAL_QUAD_[E_QUADRATIC]:   "<< params_override->fit_params.at(STR_ENERGY_QUADRATIC).value <<"\n";
+        out_stream << "CAL_QUAD_[E_QUADRATIC]_MIN:   "<< params_override->fit_params.at(STR_ENERGY_QUADRATIC).min_val <<"\n";
+        out_stream << "CAL_QUAD_[E_QUADRATIC]_MAX:   "<< params_override->fit_params.at(STR_ENERGY_QUADRATIC).max_val <<"\n";
+        out_stream << "    energy_resolution at 0keV\n";
+        out_stream << "FWHM_OFFSET: "<< params_override->fit_params.at(STR_FWHM_OFFSET).value << "\n";
+        out_stream << "    energy dependence of the energy resolution\n";
+        out_stream << "FWHM_FANOPRIME: " << params_override->fit_params.at(STR_FWHM_FANOPRIME).value << "\n";
+        out_stream << "    incident energy\n";
+        out_stream << "COHERENT_SCT_ENERGY: : " << params_override->fit_params.at(STR_COHERENT_SCT_ENERGY).value << "\n";
+        out_stream << "    upper contstraint for the incident energy\n";
+        out_stream << "COHERENT_SCT_ENERGY_MAX: " << params_override->fit_params.at(STR_COHERENT_SCT_ENERGY).max_val << "\n";
+        out_stream << "    lower contstraint for the incident energy\n";
+        out_stream << "COHERENT_SCT_ENERGY_MIN: " << params_override->fit_params.at(STR_COHERENT_SCT_ENERGY).min_val << "\n";
+        out_stream << "    angle for the compton scatter (in degrees)\n";
+        out_stream << "COMPTON_ANGLE: " << params_override->fit_params.at(STR_COMPTON_ANGLE).value << "\n";
+        out_stream << "COMPTON_ANGLE_MAX: " << params_override->fit_params.at(STR_COMPTON_ANGLE).max_val << "\n";
+        out_stream << "COMPTON_ANGLE_MIN: " << params_override->fit_params.at(STR_COMPTON_ANGLE).min_val << "\n";
+        out_stream << "    additional width of the compton\n";
+        out_stream << "COMPTON_FWHM_CORR: " << params_override->fit_params.at(STR_COMPTON_FWHM_CORR).value << "\n";
+        out_stream << "COMPTON_STEP: " << params_override->fit_params.at(STR_COMPTON_F_STEP).value << "\n";
+        out_stream << "COMPTON_F_TAIL: " << params_override->fit_params.at(STR_COMPTON_F_TAIL).value << "\n";
+        out_stream << "COMPTON_GAMMA: " << params_override->fit_params.at(STR_COMPTON_GAMMA).value << "\n";
+        out_stream << "COMPTON_HI_F_TAIL: " << params_override->fit_params.at(STR_COMPTON_HI_F_TAIL).value << "\n";
+        out_stream << "COMPTON_HI_GAMMA: " << params_override->fit_params.at(STR_COMPTON_HI_GAMMA).value << "\n";
+        out_stream << "    tailing parameters, see also Grieken, Markowicz, Handbook of X-ray spectrometry\n";
+        out_stream << "    2nd ed, van Espen spectrum evaluation page 287.  _A corresponds to f_S, _B to\n";
+        out_stream << "    f_T and _C to gamma\n";
+        out_stream << "STEP_OFFSET: " << params_override->fit_params.at(STR_F_STEP_OFFSET).value << "\n";
+        out_stream << "STEP_LINEAR: " << params_override->fit_params.at(STR_F_STEP_LINEAR).value << "\n";
+        out_stream << "STEP_QUADRATIC: " << params_override->fit_params.at(STR_F_STEP_QUADRATIC).value << "\n";
+        out_stream << "F_TAIL_OFFSET: " << params_override->fit_params.at(STR_F_TAIL_OFFSET).value << "\n";
+        out_stream << "F_TAIL_LINEAR: " << params_override->fit_params.at(STR_F_TAIL_LINEAR).value << "\n";
+        out_stream << "F_TAIL_QUADRATIC: " << params_override->fit_params.at(STR_F_TAIL_QUADRATIC).value << "\n";
+        out_stream << "KB_F_TAIL_OFFSET: " << params_override->fit_params.at(STR_KB_F_TAIL_OFFSET).value << "\n";
+        out_stream << "KB_F_TAIL_LINEAR: " << params_override->fit_params.at(STR_KB_F_TAIL_LINEAR).value << "\n";
+        out_stream << "KB_F_TAIL_QUADRATIC: " << params_override->fit_params.at(STR_KB_F_TAIL_QUADRATIC).value << "\n";
+        out_stream << "GAMMA_OFFSET: " << params_override->fit_params.at(STR_GAMMA_OFFSET).value << "\n";
+        out_stream << "GAMMA_LINEAR: " << params_override->fit_params.at(STR_GAMMA_LINEAR).value << "\n";
+        out_stream << "GAMMA_QUADRATIC: " << params_override->fit_params.at(STR_GAMMA_QUADRATIC).value << "\n";
+        out_stream << "    snip width is the width used for estimating background. 0.5 is typically a good start\n";
+        out_stream << "SNIP_WIDTH: " << params_override->fit_params.at(STR_SNIP_WIDTH).value << "\n";
+        out_stream << "    set FIT_SNIP_WIDTH to 1 to fit the width of the snipping for background estimate, set to 0 not to. Only use if you know what it is doing!\n";
+        out_stream << "FIT_SNIP_WIDTH: " << params_override->fit_snip_width << "\n";
+        out_stream << "    detector material: 0= Germanium, 1 = Si\n";
+        out_stream << "DETECTOR_MATERIAL: ";
+        if(params_override->detector_element == "Si")
+            out_stream << "1\n";
+        else
+            out_stream << "0\n";
+        out_stream << "    beryllium window thickness, in micrometers, typically 8 or 24\n";
+        out_stream << "BE_WINDOW_THICKNESS: " << params_override->be_window_thickness << "\n";
+        out_stream << "    thickness of the detector chip, e.g., 350 microns for an SDD\n";
+        out_stream << "DET_CHIP_THICKNESS: " << params_override->det_chip_thickness << "\n";
+        out_stream << "    thickness of the Germanium detector dead layer, in microns, for the purposes of the NBS calibration\n";
+        out_stream << "GE_DEAD_LAYER: " << params_override->ge_dead_layer << "\n";
+        out_stream << "    maximum energy value to fit up to [keV]\n";
+        out_stream << "MAX_ENERGY_TO_FIT: " << params_override->fit_params.at(STR_MAX_ENERGY_TO_FIT).value << "\n";
+        out_stream << "    minimum energy value [keV]\n";
+        out_stream << "MIN_ENERGY_TO_FIT: " << params_override->fit_params.at(STR_MIN_ENERGY_TO_FIT).value << "\n";
+        out_stream << "    this allows manual adjustment of the branhcing ratios between the different lines of L1, L2, and L3.\n";
+        out_stream << "    note, the numbers that are put in should be RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value,\n";
+        out_stream << "    0.8 will correspond to to 80% of that, etc.\n";
+        for (const auto& itr : params_override->branching_family_L)
+        {
+            out_stream << itr <<"\n";
+        }
+        out_stream << "    this allows manual adjustment of the branhcing ratios between the different L lines, such as La 1, la2, etc.\n";
+        out_stream << "    Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.\n";
+        out_stream << "    all will be normalized to the La1 line, and the values need to be in the following order:\n";
+        out_stream << "    La1, La2, Lb1, Lb2, Lb3, Lb4, Lg1, Lg2, Lg3, Lg4, Ll, Ln\n";
+        out_stream << "    please note, the first value (la1) MUST BE A 1. !!!\n";
+        for (const auto& itr : params_override->branching_ratio_L)
+        {
+            out_stream << itr << "\n";
+        }
+        out_stream << "    this allows manual adjustment of the branhcing ratios between the different K lines, such as Ka1, Ka2, Kb1, Kb2\n";
+        out_stream << "    Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.\n";
+        out_stream << "    all will be normalized to the Ka1 line, and the values need to be in the following order:\n";
+        out_stream << "    Ka1, Ka2, Kb1(+3), Kb2\n";
+        out_stream << "    please note, the first value (Ka1) MUST BE A 1. !!!\n";
+        for (const auto& itr : params_override->branching_ratio_K)
+        {
+            out_stream << itr << "\n";
+        }
+        out_stream << "    the parameter adds the escape peaks (offset) to the fit if larger than 0. You should not enable Si and Ge at the same time, ie, one of these two values should be zero\n";
+        out_stream << "SI_ESCAPE_FACTOR: " << params_override->si_escape_factor << "\n";
+        out_stream << "GE_ESCAPE_FACTOR: " << params_override->ge_escape_factor << "\n";
+        out_stream << "    this parameter adds a component to the escape peak that depends linear on energy\n";
+        out_stream << "LINEAR_ESCAPE_FACTOR: 0.0\n";
+        out_stream << "    the parameter enables fitting of the escape peak strengths. set 1 to enable, set to 0 to disable. (in matrix fitting always disabled)\n";
+        out_stream << "SI_ESCAPE_ENABLE: " << params_override->si_escape_enabled << "\n";
+        out_stream << "GE_ESCAPE_ENABLE: " << params_override->ge_escape_enabled << "\n";
+        out_stream << "    the lines below(if any) give backup description of IC amplifier sensitivity, in case it cannot be found in the mda file\n";
+        out_stream << "    for the amps, the _NUM value should be between 0 and 8 where 0 = 1, 1 = 2, 2 = 5, 3 = 10, 4 = 20, 5 = 50, 6 = 100, 7 = 200, 8 = 500\n";
+        out_stream << "    for the amps, the _UNIT value should be between 0 and 3 where 0 = pa / v, 1 = na / v, 2 = ua / v 3 = ma / v\n";
+        out_stream << "US_AMP_SENS_NUM: " << params_override->us_amp_sens_num << "\n";
+        out_stream << "US_AMP_SENS_UNIT: " << params_override->us_amp_sens_unit << "\n";
+        out_stream << "DS_AMP_SENS_NUM: " << params_override->ds_amp_sens_num << "\n";
+        out_stream << "DS_AMP_SENS_UNIT: "<< params_override->ds_amp_sens_unit <<"\n";
+        out_stream << "THETA_PV: " << params_override->theta_pv << "\n";
+        out_stream << "    the lines (if any) below will override the detector names built in to maps. please modify only if you are sure you understand the effect\n";
+        for (const auto& itr : params_override->scaler_pvs)
+        {
+            out_stream << itr.first << ":" << itr.second << "\n";
+        }
+        out_stream << "TIME_SCALER_PV: " << params_override->time_scaler << "\n";
+        out_stream << "TIME_SCALER_CLOCK: " << params_override->time_scaler_clock << "\n";
+        for (const auto& itr : params_override->time_normalized_scalers)
+        {
+            out_stream <<"TIME_NORMALIZED_SCALER: "<< itr.first << ";" << itr.second << "\n";
+        }
+
+        for (const auto& itr : params_override->summed_scalers)
+        {
+            if (itr.normalize_by_time)
+            {
+                out_stream << "TIME_NORMALIZED_SUMMED_SCALER: " << itr.scaler_name << ":";
+                for (const auto& inner_itr : itr.scalers_to_sum)
+                {
+                    out_stream << inner_itr << ",";
+                }
+                out_stream << "\n";
+            }
+            else
+            {
+                out_stream << "SUMMED_SCALER: "<< itr.scaler_name<<":";
+                for (const auto& inner_itr : itr.scalers_to_sum)
+                {
+                    out_stream << inner_itr << ",";
+                }
+                out_stream << "\n";
+            }
+        }
+
+        out_stream.close();
+        return true;
+    }
+    logE << "Failed to open file " << path << "\n";
     return false;
 }
 

--- a/src/io/file/csv_io.cpp
+++ b/src/io/file/csv_io.cpp
@@ -61,27 +61,19 @@ namespace io
 {
 namespace file
 {
-
-CSV_IO::CSV_IO()
+namespace csv
 {
 
-}
-
-CSV_IO::~CSV_IO()
-{
-
-}
-
-bool CSV_IO::save_fit_parameters(std::string fullpath, data_struct::ArrayXr& energy, data_struct::ArrayXr& spectra, data_struct::ArrayXr& spectra_model, data_struct::ArrayXr& background)
+bool save_fit_and_int_spectra(std::string fullpath, data_struct::ArrayXr& energy, data_struct::ArrayXr& spectra, data_struct::ArrayXr& spectra_model, data_struct::ArrayXr& background)
 {
     std::ofstream file_stream(fullpath);
-    if(file_stream.is_open())
+    if (file_stream.is_open())
     {
-        file_stream<<"Energy,Spectrum,Fitted,Background"<<"\n";
+        file_stream << "Energy,Spectrum,Fitted,Background,K alpha, K beta, L Lines, M Lines, step, tail, elastic, compton, pileip, escape" << "\n";
 
-        for (int i=0; i<energy.size(); i++)
+        for (int i = 0; i < energy.size(); i++)
         {
-            file_stream<<energy(i)<<","<<spectra(i)<<","<<spectra_model(i)<<","<<background(i)<<"\n";
+            file_stream << energy(i) << "," << spectra(i) << "," << spectra_model(i) << "," << background(i) << ",0,0,0,0,0,0,0,0,0,0\n";
         }
         file_stream.close();
     }
@@ -92,9 +84,9 @@ bool CSV_IO::save_fit_parameters(std::string fullpath, data_struct::ArrayXr& ene
     return true;
 }
 
-bool load_element_info_from_csv(std::string filename)
+bool load_element_info(std::string filename)
 {
-    data_struct::Element_Info_Map *element_map = data_struct::Element_Info_Map::inst();
+    data_struct::Element_Info_Map* element_map = data_struct::Element_Info_Map::inst();
 
     std::ifstream file_stream(filename);
     try
@@ -123,10 +115,10 @@ bool load_element_info_from_csv(std::string filename)
                 std::getline(strstream, el_name, ',');
                 if (element == nullptr)
                 {
-                     element = new Element_Info();
-                     element->number = element_number;
-                     element->name = el_name;
-                     element_map->add_element(element);
+                    element = new Element_Info();
+                    element->number = element_number;
+                    element->name = el_name;
+                    element_map->add_element(element);
                 }
                 else
                 {
@@ -327,9 +319,9 @@ bool load_element_info_from_csv(std::string filename)
             }
         }
     }
-    catch(std::exception& e)
+    catch (std::exception & e)
     {
-        if (file_stream.eof() == 0 && (file_stream.bad() || file_stream.fail()) )
+        if (file_stream.eof() == 0 && (file_stream.bad() || file_stream.fail()))
         {
             std::cerr << "ios Exception happened: " << e.what() << "\n"
                 << "Error bits are: "
@@ -343,6 +335,6 @@ bool load_element_info_from_csv(std::string filename)
     return true;
 }
 
-
-} //end namespace file
+}// end namespace csv
+}// end namespace file
 }// end namespace io

--- a/src/io/file/csv_io.h
+++ b/src/io/file/csv_io.h
@@ -60,34 +60,13 @@ namespace io
 {
 namespace file
 {
-
-class DLL_EXPORT CSV_IO
+namespace csv
 {
-public:
+    DLL_EXPORT bool save_fit_and_int_spectra(std::string fullpath, data_struct::ArrayXr& energy, data_struct::ArrayXr& spectra, data_struct::ArrayXr& spectra_model, data_struct::ArrayXr& background);
 
-    /**
-     * @brief CSV_IO
-     * @param filename
-     * @return
-     */
-    CSV_IO();
+    DLL_EXPORT bool load_element_info(std::string filename);
 
-    /**
-     * @brief ~CSV_IO
-     * @return
-     */
-    ~CSV_IO();
-
-    bool save_fit_parameters(std::string fullpath, data_struct::ArrayXr& energy, data_struct::ArrayXr& spectra, data_struct::ArrayXr& spectra_model, data_struct::ArrayXr& background);
-
-private:
-
-
-};
-
-
-DLL_EXPORT bool load_element_info_from_csv(std::string filename);
-
+}// end namespace CSV
 }// end namespace file
 }// end namespace io
 

--- a/src/io/file/hdf5_io.cpp
+++ b/src/io/file/hdf5_io.cpp
@@ -6864,14 +6864,14 @@ void HDF5_IO::update_theta(std::string dataset_file, std::string theta_pv_str)
 void HDF5_IO::update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, data_struct::Scan_Info* scna_info)
 {
     std::lock_guard<std::mutex> lock(_mutex);
-    if (scalers_map == nullptr || params_override == nullptr)
+    if (scna_info == nullptr || params_override == nullptr)
     {
         return;
     }
 
     hid_t maps_grp_id;
 
-    _save_scalers(maps_grp_id, scalers_map, nullptr, params_override, false);
+    _save_scalers(maps_grp_id, &(scna_info->scaler_maps), nullptr, params_override, false);
 
 }
 

--- a/src/io/file/hdf5_io.cpp
+++ b/src/io/file/hdf5_io.cpp
@@ -4010,7 +4010,7 @@ bool HDF5_IO::_save_params_override(hid_t group_id, data_struct::Params_Override
 
 //-----------------------------------------------------------------------------
 
-bool HDF5_IO::_save_scan_meta_data(hid_t scan_grp_id, struct mda_file *mda_scalers, data_struct::Params_Override * params_override)
+bool HDF5_IO::_save_scan_meta_data(hid_t scan_grp_id, data_struct::Scan_Meta_Info* meta_info)
 {
     
     hid_t dataspace_id = -1, memoryspace_id = -1, filespace_id = -1;
@@ -4021,8 +4021,6 @@ bool HDF5_IO::_save_scan_meta_data(hid_t scan_grp_id, struct mda_file *mda_scale
 	hsize_t offset[1] = { 0 };
 	hsize_t count[1] = { 1 };
 
-	bool single_row_scan = false;
-    
 	try
 	{
 
@@ -4031,290 +4029,84 @@ bool HDF5_IO::_save_scan_meta_data(hid_t scan_grp_id, struct mda_file *mda_scale
 		memtype = H5Tcopy(H5T_C_S1);
         status = H5Tset_size(memtype, 255);
 
-
         memoryspace_id = H5Screate_simple(1, count, nullptr);
-
-		//save scan positions
-		if (mda_scalers->scan->scan_rank > 1)
+		
+        //save y axis
+        count[0] = meta_info->y_axis.size();
+        dataspace_id = H5Screate_simple(1, count, nullptr);
+        filespace_id = H5Screate_simple(1, count, nullptr);
+        dset_id = H5Dcreate(scan_grp_id, "y_axis", H5T_INTEL_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+		if (dset_id > 0)
 		{
-			if (mda_scalers->header->data_rank == 2)
-			{
-				if (mda_scalers->header->dimensions[1] == 2000)
-				{
-					single_row_scan = true;
-				}
-			}
-
-			if (single_row_scan)
-			{
-				count[0] = 1;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "y_axis", H5T_INTEL_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-				if (dset_id < 0)
-				{
-                    logE << "creating dataset 'y_axis'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-					return false;
-				}
-				H5Dclose(dset_id);
-				H5Sclose(dataspace_id);
-
-                if(mda_scalers->scan->last_point == 0)
-                    count[0] = 1;
-                else
-                    count[0] = mda_scalers->scan->last_point;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "x_axis", H5T_INTEL_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-				if (dset_id < 0)
-				{
-                    logE << "creating dataset 'x_axis'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-					return false;
-				}
-				count[0] = 1;
-				for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
-				{
-					offset[0] = i;
-					double pos = mda_scalers->scan->positioners_data[0][i];
-                    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET, offset, nullptr, count, nullptr);
-                    status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&pos);
-				}
-				H5Dclose(dset_id);
-				H5Sclose(dataspace_id);
-				H5Sclose(filespace_id);
-
-
-                //save requested rows
-                count[0] = 1;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "requested_rows", H5T_INTEL_I32, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-                if (dset_id < 0)
-                {
-                    logE << "creating dataset 'requested_rows'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-                    return false;
-                }
-                int value = 1;
-                status = H5Dwrite(dset_id, H5T_NATIVE_INT, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&value);
-                H5Dclose(dset_id);
-                H5Sclose(dataspace_id);
-                H5Sclose(filespace_id);
-
-                //save requested cols
-                count[0] = 1;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "requested_cols", H5T_INTEL_I32, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-                if (dset_id < 0)
-                {
-                    logE << "creating dataset 'requested_cols'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-                    return false;
-                }
-                value = mda_scalers->header->dimensions[0];
-                status = H5Dwrite(dset_id, H5T_NATIVE_INT, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&value);
-                H5Dclose(dset_id);
-                H5Sclose(dataspace_id);
-                H5Sclose(filespace_id);
-
-			}
-			else
-			{
-                //save y axis
-                if(mda_scalers->scan->last_point == 0)
-                    count[0] = 1;
-                else
-                    count[0] = mda_scalers->scan->last_point;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "y_axis", H5T_INTEL_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-				if (dset_id < 0)
-				{
-                    logE << "creating dataset 'y_axis'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-					return false;
-				}
-				count[0] = 1;
-				for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
-				{
-					offset[0] = i;
-					double pos = mda_scalers->scan->positioners_data[0][i];
-                    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET, offset, nullptr, count, nullptr);
-                    status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&pos);
-				}
-				H5Dclose(dset_id);
-				H5Sclose(dataspace_id);
-				H5Sclose(filespace_id);
-
-                //save x axis
-                if(mda_scalers->scan->sub_scans[0]->last_point == 0)
-                    count[0] = 1;
-                else
-                    count[0] = mda_scalers->scan->sub_scans[0]->last_point;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "x_axis", H5T_INTEL_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-				if (dset_id < 0)
-				{
-                    logE << "creating dataset 'x_axis'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-					return false;
-				}
-				count[0] = 1;
-				for (int32_t i = 0; i < mda_scalers->scan->sub_scans[0]->last_point; i++)
-				{
-					offset[0] = i;
-					double pos = mda_scalers->scan->sub_scans[0]->positioners_data[0][i];
-                    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET, offset, nullptr, count, nullptr);
-                    status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&pos);
-				}
-				H5Dclose(dset_id);
-				H5Sclose(dataspace_id);
-				H5Sclose(filespace_id);
-
-
-                //save requested rows
-                count[0] = 1;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "requested_rows", H5T_INTEL_I32, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-                if (dset_id < 0)
-                {
-                    logE << "creating dataset 'requested_rows'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-                    return false;
-                }
-                int value = mda_scalers->header->dimensions[0];
-                status = H5Dwrite(dset_id, H5T_NATIVE_INT, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&value);
-                H5Dclose(dset_id);
-                H5Sclose(dataspace_id);
-                H5Sclose(filespace_id);
-
-                //save requested cols
-                count[0] = 1;
-                dataspace_id = H5Screate_simple(1, count, nullptr);
-                filespace_id = H5Screate_simple(1, count, nullptr);
-                dset_id = H5Dcreate(scan_grp_id, "requested_cols", H5T_INTEL_I32, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-                if (dset_id < 0)
-                {
-                    logE << "creating dataset 'requested_cols'" << "\n";
-                    H5Sclose(dataspace_id);
-                    H5Sclose(filespace_id);
-                    return false;
-                }
-                value = mda_scalers->header->dimensions[1];
-                status = H5Dwrite(dset_id, H5T_NATIVE_INT, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&value);
-                H5Dclose(dset_id);
-                H5Sclose(dataspace_id);
-                H5Sclose(filespace_id);
-
-			}
-
+            status = H5Dwrite(dset_id, H5T_NATIVE_REAL, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)meta_info->y_axis.data());
+            H5Dclose(dset_id);
+            H5Sclose(dataspace_id);
+            H5Sclose(filespace_id);
 		}
 
-		//save write date
-		count[0] = 1;
-
+        
+        count[0] = meta_info->x_axis.size();
+        dataspace_id = H5Screate_simple(1, count, nullptr);
+        filespace_id = H5Screate_simple(1, count, nullptr);
+        dset_id = H5Dcreate(scan_grp_id, "x_axis", H5T_INTEL_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+		if (dset_id > 0)
+		{
+            status = H5Dwrite(dset_id, H5T_NATIVE_REAL, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)meta_info->x_axis.data());
+            H5Dclose(dset_id);
+            H5Sclose(dataspace_id);
+            H5Sclose(filespace_id);
+		}
+		
+        //save requested rows
+        count[0] = 1;
+        dataspace_id = H5Screate_simple(1, count, nullptr);
+        filespace_id = H5Screate_simple(1, count, nullptr);
+        dset_id = H5Dcreate(scan_grp_id, "requested_rows", H5T_INTEL_I32, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        if (dset_id > 0)
+        {
+            status = H5Dwrite(dset_id, H5T_NATIVE_INT, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&(meta_info->requested_rows));
+            H5Dclose(dset_id);
+        }
+        
+        //save requested cols
+        dset_id = H5Dcreate(scan_grp_id, "requested_cols", H5T_INTEL_I32, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        if (dset_id > 0)
+        {
+            status = H5Dwrite(dset_id, H5T_NATIVE_INT, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)&(meta_info->requested_cols));
+            H5Dclose(dset_id);
+            H5Sclose(dataspace_id);
+            H5Sclose(filespace_id);
+        }
+        
         //Save theta
         dset_id = H5Dcreate(scan_grp_id, "theta", H5T_NATIVE_REAL, memoryspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        if(dset_id > 0 && mda_scalers->extra != nullptr && params_override->theta_pv.length() > 0)
+        if(dset_id > 0)
         {
-            real_t theta = 0.0;
-            struct mda_pv * pv = nullptr;
-            //find theta by param_override->theta_pv in extra names
-            for (int16_t i = 0; i < mda_scalers->extra->number_pvs; i++)
-            {
-                pv = mda_scalers->extra->pvs[i];
-                if(pv == nullptr)
-                {
-                    continue;
-                }
-
-                if (pv->name != nullptr && params_override->theta_pv.compare(pv->name) == 0)
-                {
-                    break;
-                }
-            }
-            if( pv != nullptr)
-            {
-                switch (pv->type)
-                {
-                case EXTRA_PV_STRING:
-                    //str_val = std::string(pv->values);
-                    break;
-                case EXTRA_PV_INT16:
-                    //s_val = (short*)pv->values;
-                    //str_val = std::to_string(*s_val);
-                    break;
-                case EXTRA_PV_INT32:
-                    //i_val = (int*)pv->values;
-                    //str_val = std::to_string(*i_val);
-                    break;
-                case EXTRA_PV_FLOAT:
-                    theta = *((float*)pv->values);
-                    //str_val = std::to_string(*f_val);
-                    break;
-                case EXTRA_PV_DOUBLE:
-                    theta = *((double*)pv->values);
-                    //str_val = std::to_string(*d_val);
-                    break;
-                }
-
-                status = H5Dwrite(dset_id, H5T_NATIVE_REAL, memoryspace_id, memoryspace_id, H5P_DEFAULT, (void*)&theta);
-            }
+            status = H5Dwrite(dset_id, H5T_NATIVE_REAL, memoryspace_id, memoryspace_id, H5P_DEFAULT, (void*)&meta_info->theta);
             H5Dclose(dset_id);
-            dset_id = -1;
         }
 
 		dset_id = H5Dcreate(scan_grp_id, "scan_time_stamp", filetype, memoryspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-		if (dset_id < 0)
+		if (dset_id > 0)
 		{
-            logE << "creating dataset 'scan_time_stamp'" << "\n";
-			return false;
-		}
-		if (mda_scalers->scan->time != nullptr)
-		{
-			std::string str_time = std::string(mda_scalers->scan->time);
-            char tmp_char[255] = {0};
-            str_time.copy(tmp_char, 254);
+            char tmp_char[255] = { 0 };
+            meta_info->scan_time_stamp.copy(tmp_char, 254);
             status = H5Dwrite(dset_id, memtype, memoryspace_id, memoryspace_id, H5P_DEFAULT, (void*)tmp_char);
-		}
-        if(dset_id > -1)
-        {
             H5Dclose(dset_id);
-            dset_id = -1;
-        }
+		}
+		
 		dset_id = H5Dcreate(scan_grp_id, "name", filetype, memoryspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-		if (dset_id < 0)
+		if (dset_id > 0)
 		{
-            logE << "creating dataset 'name'" << "\n";
-			return false;
-		}
-		if(mda_scalers->scan->name != nullptr)
-		{
-			std::string str_name = std::string(mda_scalers->scan->name);
-            char tmp_char[255] = {0};
-            str_name.copy(tmp_char, 254);
+            char tmp_char[255] = { 0 };
+            meta_info->name.copy(tmp_char, 254);
             status = H5Dwrite(dset_id, memtype, memoryspace_id, memoryspace_id, H5P_DEFAULT, (void*)tmp_char);
-		}
+            H5Dclose(dset_id);
+        }
 
         H5Tclose(filetype);
         H5Tclose(memtype);
 
-        if(dset_id > -1)
-        {
-            H5Dclose(dset_id);
-            dset_id = -1;
-        }
         if(memoryspace_id > -1)
         {
             H5Sclose(memoryspace_id);
@@ -5389,7 +5181,7 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
 
 
 
-bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct::ArrayXr>* scalers_map, data_struct::Spectra_Volume* spectra_volume, data_struct::Params_Override* params_override, bool hasNetcdf)
+bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::vector<data_struct::Scaler_Map>* scalers_map, data_struct::Spectra_Volume* spectra_volume, data_struct::Params_Override* params_override, bool hasNetcdf)
 {
 
     hid_t dataspace_id = -1, memoryspace_id = -1, filespace_id = -1, filespace_name_id = -1, memoryspace_str_id = -1;
@@ -5414,7 +5206,7 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
 
     bool single_row_scan = false;
 
-    Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> scaler_mat, abs_cfg_mat, H_dpc_cfg_mat, V_dpc_cfg_mat, dia1_dpc_cfg_mat, dia2_dpc_cfg_mat;
+  //  Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> scaler_mat, abs_cfg_mat, H_dpc_cfg_mat, V_dpc_cfg_mat, dia1_dpc_cfg_mat, dia2_dpc_cfg_mat;
 
     //don't save these scalers
     //std::list<std::string> ignore_scaler_strings = { "ELT1", "ERT1", "ICR1", "OCR1" };
@@ -5435,123 +5227,9 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
 
         real_t val;
         std::string units;
-        bool save_cfg_abs = false;
         
-        if (params_override != nullptr && mda_scalers->scan->scan_rank > 1)
+        if (scalers_map != nullptr)
         {
-            int us_ic_idx = -1;
-            int ds_ic_idx = -1;
-            int cfg_2_idx = -1;
-            int cfg_3_idx = -1;
-            int cfg_4_idx = -1;
-            int cfg_5_idx = -1;
-
-            int hdf_idx = 0;
-
-            if (params_override->time_scaler_clock.length() > 0)
-            {
-                time_scaler_clock = std::stod(params_override->time_scaler_clock);
-            }
-
-            for (auto itr : params_override->scaler_pvs)
-            {
-                //don't save ELT1, ERT1, ICR1, OCR1. these are saved elsewhere
-                std::list<std::string>::iterator s_itr = std::find(ignore_scaler_strings.begin(), ignore_scaler_strings.end(), itr.first);
-                if (s_itr != ignore_scaler_strings.end())
-                    continue;
-
-                int mda_idx = mda_io.find_scaler_index(mda_scalers, itr.second, val, units);
-                scalers.push_back(scaler_struct(itr.first, units, mda_idx, hdf_idx, false));
-                hdf_idx++;
-                std::string scaler_name = itr.first;
-                std::transform(scaler_name.begin(), scaler_name.end(), scaler_name.begin(), ::toupper);
-                if (mda_idx > -1)
-                {
-                    if (scaler_name == "US_IC")
-                        us_ic_idx = mda_idx;
-                    else if (scaler_name == "DS_IC")
-                        ds_ic_idx = mda_idx;
-                    else if (scaler_name == "CFG_2")
-                        cfg_2_idx = mda_idx;
-                    else if (scaler_name == "CFG_3")
-                        cfg_3_idx = mda_idx;
-                    else if (scaler_name == "CFG_4")
-                        cfg_4_idx = mda_idx;
-                    else if (scaler_name == "CFG_5")
-                        cfg_5_idx = mda_idx;
-                }
-            }
-            for (auto itr : params_override->time_normalized_scalers)
-            {
-                //don't save ELT1, ERT1, ICR1, OCR1. these are saved elsewhere
-                std::list<std::string>::iterator s_itr = std::find(ignore_scaler_strings.begin(), ignore_scaler_strings.end(), itr.first);
-                if (s_itr != ignore_scaler_strings.end())
-                    continue;
-
-                std::string scaler_name = itr.first;
-                std::transform(scaler_name.begin(), scaler_name.end(), scaler_name.begin(), ::toupper);
-
-
-                int mda_idx = mda_io.find_scaler_index(mda_scalers, itr.second, val, units);
-                if (mda_idx > -1)
-                {
-                    bool found_scaler = false;
-                    for (auto& subitr : scalers)
-                    {
-                        if (subitr.hdf_name == itr.first)
-                        {
-                            subitr.mda_idx = mda_idx;
-                            subitr.normalize_by_time = true;
-                            subitr.hdf_units = units;
-                            found_scaler = true;
-                            break;
-                        }
-                    }
-                    if (found_scaler == false)
-                    {
-                        scalers.push_back(scaler_struct(itr.first, units, mda_idx, hdf_idx, true));
-                        hdf_idx++;
-                    }
-                    if (scaler_name == "US_IC")
-                        us_ic_idx = mda_idx;
-                    else if (scaler_name == "DS_IC")
-                        ds_ic_idx = mda_idx;
-                    else if (scaler_name == "CFG_2")
-                        cfg_2_idx = mda_idx;
-                    else if (scaler_name == "CFG_3")
-                        cfg_3_idx = mda_idx;
-                    else if (scaler_name == "CFG_4")
-                        cfg_4_idx = mda_idx;
-                    else if (scaler_name == "CFG_5")
-                        cfg_5_idx = mda_idx;
-                }
-            }
-
-            // Maps summed scaler name to scaler mda index
-            for (auto& itr : params_override->summed_scalers)
-            {
-                bool found = false;
-                for (auto& scaler_itr : itr.scalers_to_sum)
-                {
-                    for (auto& found_scalers_itr : scalers)
-                    {
-                        if (scaler_itr.first == found_scalers_itr.hdf_name && itr.normalize_by_time == found_scalers_itr.normalize_by_time)
-                        {
-                            scaler_itr.second = found_scalers_itr.mda_idx;
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-                if (found)
-                {
-                    summed_scalers.push_back(itr);
-                }
-            }
-
-            //search for time scaler index
-            mda_time_scaler_idx = mda_io.find_scaler_index(mda_scalers, params_override->time_scaler, val, units);
-
             scalers_grp_id = H5Gopen(maps_grp_id, "Scalers", H5P_DEFAULT);
             if (scalers_grp_id < 0)
                 scalers_grp_id = H5Gcreate(maps_grp_id, "Scalers", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -5561,79 +5239,27 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
                 return false;
             }
 
-            _save_amps(scalers_grp_id, mda_scalers, params_override);
+            _save_amps(scalers_grp_id, params_override);
 
-            if (scalers.size() > 0)
+            if (scalers_map->size() > 0)
             {
+                count_3d[0] = scalers_map->size();
+                for (const auto &itr : *scalers_map)
+                {
+                    count_3d[1] = itr.values.rows();
+                    count_3d[2] = itr.values.cols();
+                    break;
+                }
 
-                if (mda_scalers->header->data_rank == 2)
-                {
-                    if (hasNetcdf)
-                    {
-                        count_3d[0] = 1;
-                        if (mda_scalers->scan->last_point == 0)
-                            count_3d[1] = 1;
-                        else
-                            count_3d[1] = mda_scalers->scan->last_point;
-                        if (mda_scalers->scan->sub_scans[0]->last_point == 0)
-                            count_3d[2] = 1;
-                        else
-                            count_3d[2] = mda_scalers->scan->sub_scans[0]->last_point;
-                    }
-                    else
-                    {
-                        if (mda_scalers->header->dimensions[1] == 2000)
-                        {
-                            count_3d[0] = 1;
-                            count_3d[1] = 1;
-                            if (mda_scalers->scan->last_point == 0)
-                                count_3d[2] = 1;
-                            else
-                                count_3d[2] = mda_scalers->scan->last_point;
-                            single_row_scan = true;
-                        }
-                        else
-                        {
-                            logE << "Unknown or bad mda file" << "\n";
-                        }
-                    }
-                }
-                else if (mda_scalers->header->data_rank == 3)
-                {
-                    count_3d[0] = 1;
-                    if (mda_scalers->scan->last_point == 0)
-                        count_3d[1] = 1;
-                    else
-                        count_3d[1] = mda_scalers->scan->last_point;
-                    if (mda_scalers->scan->sub_scans[0]->last_point == 0)
-                        count_3d[2] = 1;
-                    else
-                        count_3d[2] = mda_scalers->scan->sub_scans[0]->last_point;
-                }
-                else
-                {
-                    logE << "Unsupported rank " << mda_scalers->header->data_rank << " . Skipping scalers" << "\n";
-                    return false;
-                }
+                //if (spectra_volume != nullptr)
+                //{
+                //    // if we have spectra volume loaded, save elt, ert, in_cnt, and out_cnt scalers
+                //    count_3d[0] += 4;
+                //}
+
                 dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
                 H5Pset_chunk(dcpl_id, 3, count_3d);
                 H5Pset_deflate(dcpl_id, 7);
-
-                if (us_ic_idx > -1 && ds_ic_idx > -1 && cfg_2_idx > -1 && cfg_3_idx > -1 && cfg_4_idx > -1 && cfg_5_idx > -1)
-                {
-                    count_3d[0] = scalers.size() + summed_scalers.size() + 6; //abs_ic, abs_cfg, H_dpc_cfg, V_dpc_cfg, dia1_dpc_cfg, dia2_dpc_cfg
-                    save_cfg_abs = true;
-                }
-                else
-                {
-                    count_3d[0] = scalers.size() + summed_scalers.size();
-                }
-
-                if (spectra_volume != nullptr)
-                {
-                    // if we have spectra volume loaded, save elt, ert, in_cnt, and out_cnt scalers
-                    count_3d[0] += 4;
-                }
 
                 dataspace_id = H5Screate_simple(3, count_3d, NULL);
                 filespace_id = H5Screate_simple(3, count_3d, NULL);
@@ -5641,183 +5267,65 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
                 count[0] = count_3d[0];
                 filespace_name_id = H5Screate_simple(1, count, NULL);
 
-                dset_cps_id = H5Dcreate(scalers_grp_id, "Values", H5T_INTEL_R, dataspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
-                dset_names_id = H5Dcreate(scalers_grp_id, "Names", filetype, filespace_name_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-                dset_units_id = H5Dcreate(scalers_grp_id, "Units", filetype, filespace_name_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-
+                dset_cps_id = H5Dopen(scalers_grp_id, "Unmapped_Values", H5P_DEFAULT);
+                if (dset_cps_id < 0)
+                {
+                    dset_cps_id = H5Dcreate(scalers_grp_id, "Unmapped_Values", H5T_INTEL_R, dataspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+                    if (dset_cps_id < 0)
+                    {
+                        logE << " Could not open or create /MAPS/Scalers/Unmapped_Values\n";
+                        return false;
+                    }
+                }
+                dset_names_id = H5Dopen(scalers_grp_id, "Unmapped_Names", H5P_DEFAULT);
+                if (dset_names_id < 0)
+                {
+                    dset_names_id = H5Dcreate(scalers_grp_id, "Unmapped_Names", filetype, filespace_name_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+                    if (dset_names_id < 0)
+                    {
+                        logE << " Could not open or create /MAPS/Scalers/Unmapped_Names\n";
+                        return false;
+                    }
+                }
+                dset_units_id = H5Dopen(scalers_grp_id, "Unmapped_Units", H5P_DEFAULT);
+                if (dset_units_id < 0)
+                {
+                    dset_units_id = H5Dcreate(scalers_grp_id, "Unmapped_Units", filetype, filespace_name_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+                    if (dset_units_id < 0)
+                    {
+                        logE << " Could not open or create /MAPS/Scalers/Unmapped_Units\n";
+                        return false;
+                    }
+                }
                 count_3d[0] = 1;
                 count[0] = 1;
 
-                //save scalers
-                if (single_row_scan)
-                {
-                    count_2d[0] = 1;
-                    if (mda_scalers->scan->last_point == 0)
-                        count_2d[1] = 1;
-                    else
-                        count_2d[1] = mda_scalers->scan->last_point;
-                }
-                else
-                {
-                    if (mda_scalers->scan->last_point == 0)
-                        count_2d[0] = 1;
-                    else
-                        count_2d[0] = mda_scalers->scan->last_point;
-                    if (mda_scalers->scan->sub_scans[0]->last_point == 0)
-                        count_2d[1] = 1;
-                    else
-                        count_2d[1] = mda_scalers->scan->sub_scans[0]->last_point;
-                }
-                count_3d[1] = count_2d[0];
-                count_3d[2] = count_2d[1];
-
+                //save unmapped scalers
                 offset_3d[1] = 0;
                 offset_3d[2] = 0;
 
                 memoryspace_id = H5Screate_simple(2, count_2d, NULL);
 
-                scaler_mat.resize(count_2d[0], count_2d[1]);
-                scaler_mat.setZero(count_2d[0], count_2d[1]);
-
-                for (auto& itr : scalers)
+                int idx = 0;
+                for (const auto &itr : *scalers_map)
                 {
-                    scaler_mat.Zero(count_2d[0], count_2d[1]);
-                    offset[0] = itr.hdf_idx;
+                    offset[0] = idx;
+                    idx++;
                     char tmp_char[255] = { 0 };
                     char tmp_char_units[255] = { 0 };
-                    itr.hdf_name.copy(tmp_char, 254);
-                    itr.hdf_units.copy(tmp_char_units, 254);
+                    itr.name.copy(tmp_char, 254);
+                    itr.unit.copy(tmp_char_units, 254);
                     H5Sselect_hyperslab(filespace_name_id, H5S_SELECT_SET, offset, NULL, count, NULL);
                     status = H5Dwrite(dset_names_id, memtype, memoryspace_str_id, filespace_name_id, H5P_DEFAULT, (void*)tmp_char);
                     status = H5Dwrite(dset_units_id, memtype, memoryspace_str_id, filespace_name_id, H5P_DEFAULT, (void*)tmp_char_units);
-
-                    if (itr.mda_idx < 0)
-                    {
-                        continue;
-                    }
-
-                    if (single_row_scan)
-                    {
-                        for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
-                        {
-                            val = mda_scalers->scan->detectors_data[itr.mda_idx][i];
-                            if (itr.normalize_by_time && mda_time_scaler_idx > -1)
-                            {
-                                real_t scaler_time_normalizer = 1.0;
-                                real_t det_time = mda_scalers->scan->detectors_data[mda_time_scaler_idx][i];
-                                scaler_time_normalizer = det_time / time_scaler_clock;
-                                val /= scaler_time_normalizer;
-                            }
-                            if (std::isfinite(val))
-                            {
-                                scaler_mat(0, i) = val;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
-                        {
-                            for (int32_t j = 0; j < mda_scalers->scan->sub_scans[0]->last_point; j++)
-                            {
-                                val = mda_scalers->scan->sub_scans[i]->detectors_data[itr.mda_idx][j];
-                                if (itr.normalize_by_time && mda_time_scaler_idx > -1)
-                                {
-                                    real_t scaler_time_normalizer = 1.0;
-                                    real_t det_time = mda_scalers->scan->sub_scans[i]->detectors_data[mda_time_scaler_idx][j];
-                                    scaler_time_normalizer = det_time / time_scaler_clock;
-                                    val /= scaler_time_normalizer;
-                                }
-                                if (std::isfinite(val))
-                                {
-                                    scaler_mat(i, j) = val;
-                                }
-                            }
-                        }
-                    }
-
-                    offset_3d[0] = itr.hdf_idx;
                     H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET, offset_3d, NULL, count_3d, NULL);
-                    status = H5Dwrite(dset_cps_id, H5T_NATIVE_REAL, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)scaler_mat.data());
+                    status = H5Dwrite(dset_cps_id, H5T_NATIVE_REAL, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)itr.values.data());
 
                 }
-
-                for (auto& itr : summed_scalers)
-                {
-                    scaler_mat.Zero(count_2d[0], count_2d[1]);
-                    // sum values before saving. If time normalized then divide by time val
-                    offset[0] = hdf_idx;
-                    char tmp_char[255] = { 0 };
-                    //char tmp_char_units[255] = { 0 };
-                    itr.scaler_name.copy(tmp_char, 254);
-                    //itr.hdf_units.copy(tmp_char_units, 254);
-                    H5Sselect_hyperslab(filespace_name_id, H5S_SELECT_SET, offset, NULL, count, NULL);
-                    status = H5Dwrite(dset_names_id, memtype, memoryspace_str_id, filespace_name_id, H5P_DEFAULT, (void*)tmp_char);
-                    //status = H5Dwrite(dset_units_id, memtype, memoryspace_str_id, filespace_name_id, H5P_DEFAULT, (void*)tmp_char_units);
-
-                    if (single_row_scan)
-                    {
-                        for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
-                        {
-                            scaler_mat(0, i) = 0.0;
-                            for (auto& scaler_itr : itr.scalers_to_sum)
-                            {
-                                if (scaler_itr.second < 0)
-                                {
-                                    continue;
-                                }
-                                val = mda_scalers->scan->detectors_data[scaler_itr.second][i];
-                                if (itr.normalize_by_time && mda_time_scaler_idx > -1)
-                                {
-                                    real_t scaler_time_normalizer = 1.0;
-                                    real_t det_time = mda_scalers->scan->detectors_data[mda_time_scaler_idx][i];
-                                    scaler_time_normalizer = det_time / time_scaler_clock;
-                                    val /= scaler_time_normalizer;
-                                }
-                                if (std::isfinite(val))
-                                {
-                                    scaler_mat(0, i) += val;
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
-                        {
-                            for (int32_t j = 0; j < mda_scalers->scan->sub_scans[0]->last_point; j++)
-                            {
-                                scaler_mat(i, j) = 0.0;
-                                for (auto& scaler_itr : itr.scalers_to_sum)
-                                {
-                                    if (scaler_itr.second < 0)
-                                    {
-                                        continue;
-                                    }
-                                    val = mda_scalers->scan->sub_scans[i]->detectors_data[scaler_itr.second][j];
-                                    if (itr.normalize_by_time && mda_time_scaler_idx > -1)
-                                    {
-                                        real_t scaler_time_normalizer = 1.0;
-                                        real_t det_time = mda_scalers->scan->sub_scans[i]->detectors_data[mda_time_scaler_idx][j];
-                                        scaler_time_normalizer = det_time / time_scaler_clock;
-                                        val /= scaler_time_normalizer;
-                                    }
-                                    if (std::isfinite(val))
-                                    {
-                                        scaler_mat(i, j) += val;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    offset_3d[0] = hdf_idx;
-                    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET, offset_3d, NULL, count_3d, NULL);
-                    status = H5Dwrite(dset_cps_id, H5T_NATIVE_REAL, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)scaler_mat.data());
-                    hdf_idx++;
-                }
-
-                if (spectra_volume != nullptr)
+            }
+                
+            /*
+            if (spectra_volume != nullptr)
                 {
                     Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> elt_map, ert_map, in_cnt_map, out_cnt_map;
                     spectra_volume->generate_scaler_maps(&elt_map, &ert_map, &in_cnt_map, &out_cnt_map);
@@ -5912,54 +5420,6 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
                     dia1_dpc_cfg_mat.setZero(count_2d[0], count_2d[1]);
                     dia2_dpc_cfg_mat.setZero(count_2d[0], count_2d[1]);
 
-                    if (single_row_scan)
-                    {
-
-                        for (int32_t j = 0; j < mda_scalers->scan->last_point; j++)
-                        {
-                            real_t us_ic = mda_scalers->scan->detectors_data[us_ic_idx][j];
-                            real_t ds_ic = mda_scalers->scan->detectors_data[ds_ic_idx][j];
-                            real_t t_2 = mda_scalers->scan->detectors_data[cfg_2_idx][j];
-                            real_t t_3 = mda_scalers->scan->detectors_data[cfg_3_idx][j];
-                            real_t t_4 = mda_scalers->scan->detectors_data[cfg_4_idx][j];
-                            real_t t_5 = mda_scalers->scan->detectors_data[cfg_5_idx][j];
-
-                            real_t t_abs = t_2 + t_3 + t_4 + t_5;
-
-                            real_t val;
-
-                            val = ds_ic / us_ic;
-                            if (std::isfinite(val))
-                            {
-                                scaler_mat(0, j) = val;
-                            }
-                            val = t_abs / us_ic;
-                            if (std::isfinite(val))
-                            {
-                                abs_cfg_mat(0, j) = val;
-                            }
-                            if (t_abs != 0.0)
-                            {
-                                H_dpc_cfg_mat(0, j) = (t_2 - t_3 - t_4 + t_5) / t_abs;
-                                V_dpc_cfg_mat(0, j) = (t_2 + t_3 - t_4 - t_5) / t_abs;
-                                dia1_dpc_cfg_mat(0, j) = (t_2 - t_4) / t_abs;
-                                dia2_dpc_cfg_mat(0, j) = (t_3 - t_5) / t_abs;
-                            }
-
-                            //							if (itr.normalize_by_time)
-                            //							{
-                            //								real_t scaler_time_normalizer = 1.0;
-                            //								if (mda_time_scaler_idx > -1)
-                            //								{
-                            //                                  real_t det_time = mda_scalers->scan->sub_scans[i]->detectors_data[mda_time_scaler_idx][i];
-                            //									scaler_time_normalizer = det_time / time_scaler_clock;
-                            //								}
-                            //								val /= scaler_time_normalizer;
-                            //							}
-
-                        }
-                    }
-                    else
                     {
                         for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
                         {
@@ -6014,9 +5474,9 @@ bool HDF5_IO::_save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct
                     H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET, offset_3d, NULL, count_3d, NULL);
                     status = H5Dwrite(dset_cps_id, H5T_NATIVE_REAL, memoryspace_id, filespace_id, H5P_DEFAULT, (void*)dia2_dpc_cfg_mat.data());
                 }
-            }
+        */    
         }
-
+        
         H5Tclose(filetype);
         H5Tclose(memtype);
 
@@ -6336,10 +5796,9 @@ void HDF5_IO::_save_amps(hid_t scalers_grp_id, data_struct::Params_Override * pa
 //-----------------------------------------------------------------------------
 
 bool HDF5_IO::save_scan_scalers(size_t detector_num,
-                                std::map<std::string, data_struct::ArrayXr> *scalers_map,
+                                data_struct::Scan_Info *scan_info,
                                 data_struct::Spectra_Volume * spectra_volume,
                                 data_struct::Params_Override * params_override,
-                                std::vector<data_struct::Extra_PV> *extra_pvs,
                                 bool hasNetcdf,
                                 size_t row_idx_start,
                                 int row_idx_end,
@@ -6353,7 +5812,7 @@ bool HDF5_IO::save_scan_scalers(size_t detector_num,
 
     hid_t scan_grp_id, maps_grp_id, po_grp_id;
 
-	if (scalers_map == nullptr)
+	if (scan_info == nullptr)
     {
         logW << "scalers_map == nullptr. Not returning from save_scan_scalers" << "\n";
 		return false;
@@ -6396,11 +5855,11 @@ bool HDF5_IO::save_scan_scalers(size_t detector_num,
 
 	_save_params_override(po_grp_id, params_override);
 
-    _save_scan_meta_data(scan_grp_id, mda_scalers, params_override);
+    _save_scan_meta_data(scan_grp_id, &(scan_info->meta_info));
 	
-    _save_extras(scan_grp_id, extra_pvs);
+    _save_extras(scan_grp_id, &(scan_info->extra_pvs));
 	
-    _save_scalers(maps_grp_id, scalers_map, spectra_volume, params_override, hasNetcdf);
+    _save_scalers(maps_grp_id, &(scan_info->scaler_maps), spectra_volume, params_override, hasNetcdf);
 
 	H5Gclose(po_grp_id);
     H5Gclose(scan_grp_id);
@@ -7402,7 +6861,7 @@ void HDF5_IO::update_theta(std::string dataset_file, std::string theta_pv_str)
 
 //-----------------------------------------------------------------------------
 
-void HDF5_IO::update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, std::map<std::string, data_struct::ArrayXr>* scalers_map)
+void HDF5_IO::update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, data_struct::Scan_Info* scna_info)
 {
     std::lock_guard<std::mutex> lock(_mutex);
     if (scalers_map == nullptr || params_override == nullptr)

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -165,6 +165,7 @@ public:
     bool save_fitted_int_spectra(const std::string path,
                                  const data_struct::Spectra& spectra,
                                  const data_struct::Range& range,
+                                 const data_struct::Spectra& background,
 								 const size_t save_spectra_size);
 	
 	bool save_max_10_spectra(const std::string path,

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -210,7 +210,7 @@ public:
     void update_theta(std::string dataset_file, std::string theta_pv_str);
 
     //update scalers if maps_fit_parameters_override.txt has changes pv's and you don't want to refit
-    void update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, std::map<std::string, data_struct::ArrayXr>* scalers_map);
+    void update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, data_struct::Scan_Info* scna_info);
     
     bool end_save_seq(bool loginfo=true);
 

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -211,6 +211,9 @@ public:
     //update scalers if maps_fit_parameters_override.txt has changes pv's and you don't want to refit
     void update_scalers(std::string dataset_file, data_struct::Params_Override* params_override);
     
+    //export integrated spec, fitted, background into csv
+    void export_int_fitted_to_csv(std::string dataset_file);
+
     bool end_save_seq(bool loginfo=true);
 
 private:

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -178,7 +178,6 @@ public:
 
     bool save_scan_scalers(size_t detector_num,
                            data_struct::Scan_Info* scan_info,
-                           data_struct::Spectra_Volume * spectra_volume,
                            data_struct::Params_Override * params_override,
                            bool hasNetcdf,
                            size_t row_idx_start=0,
@@ -226,7 +225,7 @@ private:
 
     bool _save_scan_meta_data(hid_t scan_grp_id, data_struct::Scan_Meta_Info* meta_info);
 	bool _save_extras(hid_t scan_grp_id, std::vector<data_struct::Extra_PV>* extra_pvs);
-    bool _save_scalers(hid_t maps_grp_id, std::vector<data_struct::Scaler_Map>*scalers_map, data_struct::Spectra_Volume * spectra_volume, data_struct::Params_Override * params_override, bool hasNetcdf);
+    bool _save_scalers(hid_t maps_grp_id, std::vector<data_struct::Scaler_Map>*scalers_map, data_struct::Params_Override * params_override, bool hasNetcdf);
     void _save_amps(hid_t scalers_grp_id, data_struct::Params_Override * params_override);
 	bool _save_params_override(hid_t group_id, data_struct::Params_Override * params_override);
 

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -60,6 +60,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "data_struct/fit_element_map.h"
 #include "data_struct/quantification_standard.h"
 #include "data_struct/params_override.h"
+#include "data_struct/scan_info.h"
 
 #include "core/mem_info.h"
 
@@ -176,10 +177,9 @@ public:
     bool save_quantification(data_struct::Quantification_Standard * quantification_standard);
 
     bool save_scan_scalers(size_t detector_num,
-                           std::map<std::string, data_struct::ArrayXr> *scalers_map,
+                           data_struct::Scan_Info* scan_info,
                            data_struct::Spectra_Volume * spectra_volume,
                            data_struct::Params_Override * params_override,
-                           std::vector<data_struct::Extra_PV> *extra_pvs,
                            bool hasNetcdf,
                            size_t row_idx_start=0,
                            int row_idx_end=-1,
@@ -224,9 +224,9 @@ private:
 
 	bool _load_integrated_spectra_analyzed_h5(hid_t file_id, data_struct::Spectra* spectra);
 
-    bool _save_scan_meta_data(hid_t scan_grp_id, struct mda_file *mda_scalers, data_struct::Params_Override * params_override);
+    bool _save_scan_meta_data(hid_t scan_grp_id, data_struct::Scan_Meta_Info* meta_info);
 	bool _save_extras(hid_t scan_grp_id, std::vector<data_struct::Extra_PV>* extra_pvs);
-    bool _save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct::ArrayXr> *scalers_map, data_struct::Spectra_Volume * spectra_volume, data_struct::Params_Override * params_override, bool hasNetcdf);
+    bool _save_scalers(hid_t maps_grp_id, std::vector<data_struct::Scaler_Map>*scalers_map, data_struct::Spectra_Volume * spectra_volume, data_struct::Params_Override * params_override, bool hasNetcdf);
     void _save_amps(hid_t scalers_grp_id, data_struct::Params_Override * params_override);
 	bool _save_params_override(hid_t group_id, data_struct::Params_Override * params_override);
 

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -209,7 +209,7 @@ public:
     void update_theta(std::string dataset_file, std::string theta_pv_str);
 
     //update scalers if maps_fit_parameters_override.txt has changes pv's and you don't want to refit
-    void update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, data_struct::Scan_Info* scna_info);
+    void update_scalers(std::string dataset_file, data_struct::Params_Override* params_override);
     
     bool end_save_seq(bool loginfo=true);
 

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -58,10 +58,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "hdf5.h"
 #include "data_struct/spectra_volume.h"
 #include "data_struct/fit_element_map.h"
-
-//Include mda data structures to save scalers
-#include "io/file/mda_io.h"
-
 #include "data_struct/quantification_standard.h"
 #include "data_struct/params_override.h"
 
@@ -180,9 +176,10 @@ public:
     bool save_quantification(data_struct::Quantification_Standard * quantification_standard);
 
     bool save_scan_scalers(size_t detector_num,
-                           struct mda_file *mda_scalers,
+                           std::map<std::string, data_struct::ArrayXr> *scalers_map,
                            data_struct::Spectra_Volume * spectra_volume,
                            data_struct::Params_Override * params_override,
+                           std::vector<data_struct::Extra_PV> *extra_pvs,
                            bool hasNetcdf,
                            size_t row_idx_start=0,
                            int row_idx_end=-1,
@@ -213,7 +210,7 @@ public:
     void update_theta(std::string dataset_file, std::string theta_pv_str);
 
     //update scalers if maps_fit_parameters_override.txt has changes pv's and you don't want to refit
-    void update_scalers(std::string hdf_dataset_file, std::string mda_dataset_file, data_struct::Params_Override* params_override);
+    void update_scalers(std::string dataset_file, data_struct::Params_Override* params_override, std::map<std::string, data_struct::ArrayXr>* scalers_map);
     
     bool end_save_seq(bool loginfo=true);
 
@@ -228,9 +225,9 @@ private:
 	bool _load_integrated_spectra_analyzed_h5(hid_t file_id, data_struct::Spectra* spectra);
 
     bool _save_scan_meta_data(hid_t scan_grp_id, struct mda_file *mda_scalers, data_struct::Params_Override * params_override);
-	bool _save_extras(hid_t scan_grp_id, struct mda_file *mda_scalers);
-    bool _save_scalers(hid_t maps_grp_id, struct mda_file *mda_scalers, data_struct::Spectra_Volume * spectra_volume, data_struct::Params_Override * params_override, bool hasNetcdf);
-    void _save_amps(hid_t scalers_grp_id, struct mda_file *mda_scalers, data_struct::Params_Override * params_override);
+	bool _save_extras(hid_t scan_grp_id, std::vector<data_struct::Extra_PV>* extra_pvs);
+    bool _save_scalers(hid_t maps_grp_id, std::map<std::string, data_struct::ArrayXr> *scalers_map, data_struct::Spectra_Volume * spectra_volume, data_struct::Params_Override * params_override, bool hasNetcdf);
+    void _save_amps(hid_t scalers_grp_id, data_struct::Params_Override * params_override);
 	bool _save_params_override(hid_t group_id, data_struct::Params_Override * params_override);
 
     void _gen_average(std::string full_hdf5_path, std::string dataset_name, hid_t src_analyzed_grp_id, hid_t dst_fit_grp_id, hid_t ocpypl_id, std::vector<hid_t> &hdf5_file_ids, bool avg=true);

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -168,8 +168,12 @@ public:
     bool save_fitted_int_spectra(const std::string path,
                                  const data_struct::Spectra& spectra,
                                  const data_struct::Range& range,
-								 const data_struct::Spectra& max_spectra,
-								 const data_struct::Spectra& max_10_spectra);
+								 const size_t save_spectra_size);
+	
+	bool save_max_10_spectra(const std::string path,
+							const data_struct::Range& range,
+							const data_struct::Spectra& max_spectra,
+							const data_struct::Spectra& max_10_spectra);
 
     void save_quantifications(std::map<string, data_struct::Quantification_Standard*> &quants);
 

--- a/src/io/file/hdf5_io.h
+++ b/src/io/file/hdf5_io.h
@@ -204,22 +204,17 @@ public:
 								int col_idx_end = -1);
 
 	// Add links to dataset and set version to 9 so legacy software can load it
-    void add_v9_layout(std::string dataset_directory,
-                       std::string dataset_file,
-                       const std::vector<size_t>& detector_num_arr);
+    void add_v9_layout(std::string dataset_file);
 
 	// Add exchange layout to be loadable by external software
-	void add_exchange_layout(std::string dataset_directory,
-							std::string dataset_file,
-							const std::vector<size_t>& detector_num_arr);
+    void add_exchange_layout(std::string dataset_file);
 
 	// update theta value based on new pv name
-	void update_theta(std::string dataset_directory,
-					std::string dataset_file,
-					const std::vector<size_t>& detector_num_arr,
-					std::string theta_pv_str);
+    void update_theta(std::string dataset_file, std::string theta_pv_str);
 
-
+    //update scalers if maps_fit_parameters_override.txt has changes pv's and you don't want to refit
+    void update_scalers(std::string hdf_dataset_file, std::string mda_dataset_file, data_struct::Params_Override* params_override);
+    
     bool end_save_seq(bool loginfo=true);
 
 private:
@@ -242,17 +237,13 @@ private:
     void _generate_avg_analysis(hid_t src_maps_grp_id, hid_t dst_maps_grp_id, std::string group_name, hid_t ocpypl_id, std::vector<hid_t> &hdf5_file_ids);
     void _generate_avg_integrated_spectra(hid_t src_analyzed_grp_id, hid_t dst_fit_grp_id, std::string group_name, hid_t ocpypl_id, std::vector<hid_t> &hdf5_file_ids);
 
-    void _add_v9_layout(std::string dataset_file);
     void _add_v9_quant(hid_t file_id, hid_t quant_space, hid_t chan_names, hid_t chan_space, int chan_amt, std::string quant_str, std::string new_loc);
     void _add_extra_pvs(hid_t file_id, std::string group_name);
 
     bool _add_exchange_meta(hid_t file_id, std::string exchange_idx, std::string fits_link, std::string normalize_scaler);
-	void _add_exchange_layout(std::string dataset_file);
-
+	
     bool _open_h5_object(hid_t &id, H5_OBJECTS obj, std::stack<std::pair<hid_t, H5_OBJECTS> > &close_map, std::string s1, hid_t id2, bool log_error=true, bool close_on_fail=true);
     void _close_h5_objects(std::stack<std::pair<hid_t, H5_OBJECTS> > &close_map);
-
-	void _update_theta(std::string dataset_file, std::string theta_pv_str);
 
     struct scaler_struct
     {

--- a/src/io/file/hl_file_io.cpp
+++ b/src/io/file/hl_file_io.cpp
@@ -772,8 +772,16 @@ bool load_spectra_volume(std::string dataset_directory,
 
     if(save_scalers)
     {
+        std::string mda_path = dataset_directory + "mda" + DIR_END_CHAR + dataset_file;
+        std::map<std::string, ArrayXr> scaler_map;
+        std::vector<data_struct::Extra_PV> extra_pvs;
+
+        mda_io.generate_scaler_volume(mda_path, scaler_map);
+        mda_io.search_and_update_amps(mda_path, params_override);
+        mda_io.generate_extra_pvs_vector(mda_path, extra_pvs);
+
         io::file::HDF5_IO::inst()->start_save_seq(true);
-        io::file::HDF5_IO::inst()->save_scan_scalers(detector_num, mda_io.get_scan_ptr(), spectra_volume, params_override, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress);
+        io::file::HDF5_IO::inst()->save_scan_scalers(detector_num, &scaler_map, spectra_volume, params_override, &extra_pvs, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress);
     }
 
     mda_io.unload();

--- a/src/io/file/hl_file_io.cpp
+++ b/src/io/file/hl_file_io.cpp
@@ -773,7 +773,13 @@ bool load_spectra_volume(std::string dataset_directory,
     if(save_scalers)
     {
         io::file::HDF5_IO::inst()->start_save_seq(true);
-        io::file::HDF5_IO::inst()->save_scan_scalers(detector_num, mda_io.get_scan_info(), spectra_volume, params_override, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress);
+        data_struct::Scan_Info* scan_info = mda_io.get_scan_info();
+        // add ELT, ERT, INCNT, OUTCNT to scaler map
+        if (spectra_volume != nullptr && scan_info != nullptr)
+        {
+            spectra_volume->generate_scaler_maps(&(scan_info->scaler_maps));
+        }
+        io::file::HDF5_IO::inst()->save_scan_scalers(detector_num, scan_info, params_override, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress);
     }
 
     mda_io.unload();

--- a/src/io/file/hl_file_io.cpp
+++ b/src/io/file/hl_file_io.cpp
@@ -1165,11 +1165,11 @@ void sort_dataset_files_by_size(std::string dataset_directory, std::vector<std::
         if (itr.compare(itr.length() - ending.length(), ending.length(), ending) == 0 )
         {
             std::string full_path = dataset_directory + DIR_END_CHAR+"mda"+ DIR_END_CHAR +itr;
-            int fsize = mda_io.get_multiplied_dims(full_path);
+            int fsize = file::mda_get_multiplied_dims(full_path);
             f_list.push_back(file_name_size(itr, fsize));
         }
     }
-
+    
     f_list.sort(compare_file_size);
 
     dataset_files->clear();

--- a/src/io/file/hl_file_io.cpp
+++ b/src/io/file/hl_file_io.cpp
@@ -192,7 +192,7 @@ bool load_element_info(std::string element_henke_filename, std::string element_c
 		return false;
 	}
 
-    if (io::file::load_element_info_from_csv(element_csv_filename) == false)
+    if (io::file::csv::load_element_info(element_csv_filename) == false)
 	{
 		logE << "Could not load " << element_csv_filename << "\n";
 		return false;
@@ -226,7 +226,6 @@ void save_quantification_plots(data_struct::Analysis_Job* analysis_job, map<stri
 
 void save_optimized_fit_params(struct file_name_fit_params* file_and_fit_params)
 {
-    io::file::CSV_IO csv_io;
     std::string full_path = file_and_fit_params->dataset_dir+ DIR_END_CHAR+"output"+ DIR_END_CHAR +file_and_fit_params->dataset_filename+std::to_string(file_and_fit_params->detector_num)+".csv";
     logI<<full_path<<"\n";
 
@@ -272,7 +271,7 @@ void save_optimized_fit_params(struct file_name_fit_params* file_and_fit_params)
     visual::SavePlotSpectras(str_path, &ev, &spec, &model_spectra, &background, true);
 #endif
 
-    csv_io.save_fit_parameters(full_path, ev, spec, model_spectra, background );
+    io::file::csv::save_fit_and_int_spectra(full_path, ev, spec, model_spectra, background);
 
     for(auto &itr : file_and_fit_params->elements_to_fit)
     {

--- a/src/io/file/hl_file_io.cpp
+++ b/src/io/file/hl_file_io.cpp
@@ -648,6 +648,10 @@ bool load_spectra_volume(std::string dataset_directory,
             }
         }
     }
+
+    std::string fullpath = dataset_directory + "img.dat" + DIR_END_CHAR + dataset_file + ".h5" + std::to_string(detector_num);
+
+    /*
     std::string fullpath;
     size_t dlen = dataset_file.length();
     if (dataset_file[dlen -4] == '.' && dataset_file[dlen - 3] == 'm' && dataset_file[dlen - 2] == 'd' && dataset_file[dlen - 1] == 'a')
@@ -658,6 +662,7 @@ bool load_spectra_volume(std::string dataset_directory,
     {
         fullpath = dataset_directory + "img.dat" + DIR_END_CHAR + dataset_file;
     }
+    */
     //  try to load from a pre analyzed file because they should contain the whole mca_arr spectra volume
     if(true == io::file::HDF5_IO::inst()->load_spectra_vol_analyzed_h5(fullpath, spectra_volume))
     {

--- a/src/io/file/hl_file_io.cpp
+++ b/src/io/file/hl_file_io.cpp
@@ -698,7 +698,7 @@ bool load_spectra_volume(std::string dataset_directory,
 		return true;
 	}
 
-    //load spectra
+    // try to load spectra from mda file
     if (false == mda_io.load_spectra_volume(dataset_directory+"mda"+DIR_END_CHAR+dataset_file, detector_num, spectra_volume, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress, params_override) )
     {
         logE<<"Load spectra "<<dataset_directory+"mda"+DIR_END_CHAR +dataset_file<<"\n";
@@ -772,16 +772,8 @@ bool load_spectra_volume(std::string dataset_directory,
 
     if(save_scalers)
     {
-        std::string mda_path = dataset_directory + "mda" + DIR_END_CHAR + dataset_file;
-        std::map<std::string, ArrayXr> scaler_map;
-        std::vector<data_struct::Extra_PV> extra_pvs;
-
-        mda_io.generate_scaler_volume(mda_path, scaler_map);
-        mda_io.search_and_update_amps(mda_path, params_override);
-        mda_io.generate_extra_pvs_vector(mda_path, extra_pvs);
-
         io::file::HDF5_IO::inst()->start_save_seq(true);
-        io::file::HDF5_IO::inst()->save_scan_scalers(detector_num, &scaler_map, spectra_volume, params_override, &extra_pvs, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress);
+        io::file::HDF5_IO::inst()->save_scan_scalers(detector_num, mda_io.get_scan_info(), spectra_volume, params_override, hasNetcdf | hasBnpNetcdf | hasHdf | hasXspress);
     }
 
     mda_io.unload();
@@ -927,7 +919,7 @@ bool load_and_integrate_spectra_volume(std::string dataset_directory,
             int rank;
             size_t dims[10];
             dims[0] = 0;
-            rank = mda_io.get_rank_and_dims(dataset_directory + "mda"+ DIR_END_CHAR + dataset_file, &dims[0]);
+            rank = io::file::mda_get_rank_and_dims(dataset_directory + "mda"+ DIR_END_CHAR + dataset_file, &dims[0]);
             if(rank == 3)
             {
                 integrated_spectra->resize(dims[2]);

--- a/src/io/file/hl_file_io.h
+++ b/src/io/file/hl_file_io.h
@@ -94,9 +94,9 @@ namespace io
 
 struct DLL_EXPORT file_name_size
 {
-    file_name_size(std::string name, int size) { filename = name; total_rank_size = size;}
+    file_name_size(std::string name, long size) { filename = name; total_rank_size = size;}
     std::string filename;
-    int total_rank_size;
+    long total_rank_size;
 };
 
 struct DLL_EXPORT file_name_fit_params

--- a/src/io/file/mda_io.cpp
+++ b/src/io/file/mda_io.cpp
@@ -88,7 +88,7 @@ MDA_IO::~MDA_IO()
 
 }
 
-bool MDA_IO::load(std::string path)
+bool MDA_IO::load(std::string path, data_struct::Params_Override* override_values)
 {
     if (_mda_file != nullptr)
     {

--- a/src/io/file/mda_io.cpp
+++ b/src/io/file/mda_io.cpp
@@ -359,6 +359,10 @@ bool MDA_IO::load_spectra_volume(std::string path,
     }
     logI<<"mda info ver:"<<_mda_file->header->version<<" data rank:"<<_mda_file->header->data_rank<<"\n";
 
+    _load_scalers();
+    _load_meta_info();
+    _load_extra_pvs_vector();
+
     std::string units;
     if (override_values != nullptr)
     {
@@ -919,7 +923,7 @@ void MDA_IO::_load_scalers()
     }
     size_t rows = 0;
     size_t cols = 0;
-    bool single_row_scan;
+    bool single_row_scan = false;
     if (_mda_file->header->data_rank == 2)
     {
         if (_hasNetcdf == false && _mda_file->header->dimensions[1] == 2000)

--- a/src/io/file/mda_io.cpp
+++ b/src/io/file/mda_io.cpp
@@ -346,6 +346,31 @@ bool MDA_IO::load_quantification_scalers(std::string path,
 
 //-----------------------------------------------------------------------------
 
+bool MDA_IO::load_struct(std::string path)
+{
+    std::FILE* fptr = std::fopen(path.c_str(), "rb");
+
+    size_t cols = 1;
+    size_t rows = 1;
+    size_t samples = 1;
+
+    if (fptr == nullptr)
+    {
+        return false;
+    }
+
+    _mda_file = mda_load(fptr);
+    std::fclose(fptr);
+    if (_mda_file == nullptr )
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+
 bool MDA_IO::load_spectra_volume(std::string path,
                                  size_t detector_num,
                                  data_struct::Spectra_Volume* vol,
@@ -372,7 +397,7 @@ bool MDA_IO::load_spectra_volume(std::string path,
 
     _mda_file = mda_load(fptr);
     std::fclose(fptr);
-    if (_mda_file == nullptr)
+    if (_mda_file == nullptr || vol == nullptr)
     {
         return false;
     }

--- a/src/io/file/mda_io.cpp
+++ b/src/io/file/mda_io.cpp
@@ -75,10 +75,8 @@ namespace file
 
 MDA_IO::MDA_IO()
 {
-
     _mda_file = nullptr;
     _mda_file_info = nullptr;
-    _is_single_row = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -107,33 +105,6 @@ void MDA_IO::unload()
 }
 
 //-----------------------------------------------------------------------------
-/*
-void MDA_IO::lazy_load()
-{
-
-    std::FILE *fptr = std::fopen(_filename.c_str(), "r");
-
-    _mda_file_info = mda_info_load(fptr);
-
-    std::fclose(fptr);
-
-	if (_mda_file_info == nullptr)
-	{
-        logE << "Error loading mda file:" << _filename<<"\n";
-		return;
-	}
-
-    logD<<"mda info ver:"<<_mda_file_info->version<<" data rank:"<<_mda_file_info->data_rank;
-    for(int16_t i = 0; i < _mda_file_info->data_rank; i++)
-    {
-        logit_s<<" dims["<<i<<"]:"<<_mda_file_info->dimensions[i];
-    }
-    logit_s<<"\n";
-
-}
-*/
-
-//-----------------------------------------------------------------------------
 
 bool MDA_IO::load_header(std::string filePath)
 {
@@ -154,6 +125,42 @@ bool MDA_IO::load_header(std::string filePath)
     }
     return false;
 
+}
+
+struct mda_file* open_mda(std::string path)
+{
+    struct mda_file* mda_file = nullptr;
+    std::FILE* fptr = std::fopen(path.c_str(), "rb");
+
+    if (fptr == nullptr)
+    {
+        return nullptr;
+    }
+
+    mda_file = mda_load(fptr);
+    std::fclose(fptr);
+    return mda_file;
+
+}
+
+void MDA_IO::search_and_update_amps(std::string path, data_struct::Params_Override* params_override)
+{
+
+    std::string units;
+    struct mda_file* mda_file = open_mda(path);
+    if (mda_file == nullptr || params_override == nullptr)
+    {
+        return;
+    }
+
+    // we want to search through the mda scalers for us_amp_sens_num_pv, if it isn't found then us_amp_sens_num is unchanged (uses the maps_fit_paramters_override file value)
+    find_scaler_index(mda_file, params_override->us_amp_sens_num_pv, params_override->us_amp_sens_num, units);
+    find_scaler_index(mda_file, params_override->us_amp_sens_unit_pv, params_override->us_amp_sens_unit, units);
+
+    find_scaler_index(mda_file, params_override->ds_amp_sens_num_pv, params_override->ds_amp_sens_num, units);
+    find_scaler_index(mda_file, params_override->ds_amp_sens_unit_pv, params_override->ds_amp_sens_unit, units);
+
+    mda_unload(mda_file);
 }
 
 //-----------------------------------------------------------------------------
@@ -302,69 +309,30 @@ bool MDA_IO::_get_scaler_value( struct mda_file* _mda_file, data_struct::Params_
 
 //-----------------------------------------------------------------------------
 
-bool MDA_IO::load_quantification_scalers(std::string path,
-                                        data_struct::Params_Override *override_values)
+bool MDA_IO::load_quantification_scalers(std::string path, data_struct::Params_Override *override_values)
 {
     std::string units;
-    std::FILE *fptr = std::fopen(path.c_str(), "rb");
-
-    if (fptr == nullptr)
+    struct mda_file* mda_file = open_mda(path);
+    if (mda_file == nullptr || override_values == nullptr)
     {
         return false;
     }
-
-
-    _mda_file = mda_load(fptr);
-    std::fclose(fptr);
-    if (_mda_file == nullptr)
-    {
-        return false;
-    }
-
-    if(override_values == nullptr)
-    {
-        return false;
-    }
-
 
     //Look for fly scan pv first then step scan
-    if(false == _get_scaler_value(_mda_file, override_values, "SRCURRENT", &override_values->sr_current, true))
+    if(false == _get_scaler_value(mda_file, override_values, "SRCURRENT", &override_values->sr_current, true))
     {
-        _get_scaler_value(_mda_file, override_values, "SRCURRENT", &override_values->sr_current, false);
+        _get_scaler_value(mda_file, override_values, "SRCURRENT", &override_values->sr_current, false);
     }
-    if(false == _get_scaler_value(_mda_file, override_values, "US_IC", &override_values->US_IC, true))
+    if(false == _get_scaler_value(mda_file, override_values, "US_IC", &override_values->US_IC, true))
     {
-        _get_scaler_value(_mda_file, override_values, "US_IC", &override_values->US_IC, false);
+        _get_scaler_value(mda_file, override_values, "US_IC", &override_values->US_IC, false);
     }
-    if(false == _get_scaler_value(_mda_file, override_values, "DS_IC", &override_values->DS_IC, true))
+    if(false == _get_scaler_value(mda_file, override_values, "DS_IC", &override_values->DS_IC, true))
     {
-        _get_scaler_value(_mda_file, override_values, "DS_IC", &override_values->DS_IC, false);
-    }
-
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-
-bool MDA_IO::load_struct(std::string path)
-{
-    std::FILE* fptr = std::fopen(path.c_str(), "rb");
-
-    size_t cols = 1;
-    size_t rows = 1;
-    size_t samples = 1;
-
-    if (fptr == nullptr)
-    {
-        return false;
+        _get_scaler_value(mda_file, override_values, "DS_IC", &override_values->DS_IC, false);
     }
 
-    _mda_file = mda_load(fptr);
-    std::fclose(fptr);
-    if (_mda_file == nullptr )
-    {
-        return false;
-    }
+    mda_unload(mda_file);
 
     return true;
 }
@@ -382,6 +350,7 @@ bool MDA_IO::load_spectra_volume(std::string path,
     int ert_idx = -1;
     int incnt_idx = -1;
     int outcnt_idx = -1;
+    bool is_single_row = false;
 
     std::FILE *fptr = std::fopen(path.c_str(), "rb");
 
@@ -466,7 +435,7 @@ bool MDA_IO::load_spectra_volume(std::string path,
                 cols = _mda_file->scan->last_point;
                 samples = _mda_file->header->dimensions[1];
                 vol->resize_and_zero(rows, cols, 2048); //default to 2048 since it is only 2000 saved
-                _is_single_row = true;
+                is_single_row = true;
             }
             else
             {
@@ -520,7 +489,7 @@ bool MDA_IO::load_spectra_volume(std::string path,
 
     try
     {
-        if( _is_single_row )
+        if( is_single_row )
         {
             if(_mda_file->scan->last_point < _mda_file->scan->requested_points)
             {
@@ -540,7 +509,7 @@ bool MDA_IO::load_spectra_volume(std::string path,
         {
             // update num rows if header is incorrect and not single row scan
 
-            if(false == _is_single_row)
+            if(false == is_single_row)
             {
                 if(_mda_file->scan->sub_scans[i]->last_point < _mda_file->scan->sub_scans[i]->requested_points)
                 {
@@ -558,7 +527,7 @@ bool MDA_IO::load_spectra_volume(std::string path,
 //
 
 
-                if (_is_single_row)
+                if (is_single_row)
                 {
                     if(elt_idx > -1)
                     {
@@ -637,6 +606,8 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
 												const std::vector<size_t>& detector_num_arr,
                                                  bool hasNetCDF,
                                                  data_struct::Analysis_Job *analysis_job,
+                                                 size_t &out_rows,
+                                                 size_t &out_cols,
 												 data_struct::IO_Callback_Func_Def callback_func,
                                                  void *user_data)
 {
@@ -645,6 +616,8 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
     int incnt_idx = -1;
     int outcnt_idx = -1;
     size_t max_detecotr_num = 0;
+    bool is_single_row = false;
+
     std::FILE *fptr = std::fopen(path.c_str(), "rb");
 
     size_t samples = 1;
@@ -681,13 +654,13 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
         if(hasNetCDF)
         {
             if(_mda_file->scan->last_point == 0)
-                _rows = 1;
+                out_rows = 1;
             else
-                _rows = _mda_file->scan->last_point;
+                out_rows = _mda_file->scan->last_point;
             if(_mda_file->scan->sub_scans[0]->last_point == 0)
-                _cols = 1;
+                out_cols = 1;
             else
-                _cols = _mda_file->scan->sub_scans[0]->last_point;
+                out_cols = _mda_file->scan->sub_scans[0]->last_point;
             return true;
         }
         else
@@ -701,13 +674,17 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
                     return false;
                 }
 
-                _rows = 1;
-                if(_mda_file->scan->last_point == 0)
-                    _cols = 1;
+                out_rows = 1;
+                if (_mda_file->scan->last_point == 0)
+                {
+                    out_cols = 1;
+                }
                 else
-                _cols = _mda_file->scan->last_point;
+                {
+                    out_cols = _mda_file->scan->last_point;
+                }
                 samples = _mda_file->header->dimensions[1];
-                _is_single_row = true;
+                is_single_row = true;
             }
             else
             {
@@ -728,13 +705,13 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
         }
 
         if(_mda_file->scan->last_point == 0)
-            _rows = 1;
+            out_rows = 1;
         else
-            _rows = _mda_file->scan->last_point;
+            out_rows = _mda_file->scan->last_point;
         if(_mda_file->scan->sub_scans[0]->last_point == 0)
-            _cols = 1;
+            out_cols = 1;
         else
-            _cols = _mda_file->scan->sub_scans[0]->last_point;
+            out_cols = _mda_file->scan->sub_scans[0]->last_point;
         samples = _mda_file->header->dimensions[2];
     }
     else
@@ -794,33 +771,33 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
 
     try
     {
-        if( _is_single_row )
+        if(is_single_row )
         {
             if(_mda_file->scan->last_point < _mda_file->scan->requested_points)
             {
-                _cols = _mda_file->scan->last_point;
+                out_cols = _mda_file->scan->last_point;
             }
         }
         else
         {
             if(_mda_file->scan->last_point < _mda_file->scan->requested_points)
             {
-                _rows = _mda_file->scan->last_point;
+                out_rows = _mda_file->scan->last_point;
             }
         }
 
-        for(int i=0; i<_rows; i++)
+        for(int i=0; i< out_rows; i++)
         {
             // update num rows if header is incorrect and not single row scan
 
-            if(false == _is_single_row)
+            if(false == is_single_row)
             {
                 if(_mda_file->scan->sub_scans[i]->last_point < _mda_file->scan->sub_scans[i]->requested_points)
                 {
-                    _cols = _mda_file->scan->sub_scans[i]->last_point;
+                    out_cols = _mda_file->scan->sub_scans[i]->last_point;
                 }
             }
-            for(int j=0; j<_cols; j++)
+            for(int j=0; j< out_cols; j++)
             {
 /* TODO: we might need to do the same check for samples size
                 if(_mda_file->scan->sub_scans[i]->sub_scan[j]->last_point < _mda_file->scan->sub_scans[i]->sub_scan[j]->requested_points)
@@ -834,7 +811,7 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
                     data_struct::Spectra* spectra = new data_struct::Spectra(samples);
 
 
-                    if (_is_single_row)
+                    if (is_single_row)
                     {
                         if(elt_idx > -1)
                         {
@@ -863,7 +840,7 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
 
                             (*spectra)[k] = (_mda_file->scan->sub_scans[j]->detectors_data[detector_num][k]);
                         }
-                        callback_func(i, j, _rows, _cols, detector_num, spectra, user_data);
+                        callback_func(i, j, out_rows, out_cols, detector_num, spectra, user_data);
                     }
                     else
                     {
@@ -893,7 +870,7 @@ bool MDA_IO::load_spectra_volume_with_callback(std::string path,
                         {
                             (*spectra)[k] = (_mda_file->scan->sub_scans[i]->sub_scans[j]->detectors_data[detector_num][k]);
                         }
-                        callback_func(i, j, _rows, _cols, detector_num, spectra, user_data);
+                        callback_func(i, j, out_rows, out_cols, detector_num, spectra, user_data);
                     }
                 }
             }
@@ -1018,6 +995,362 @@ int MDA_IO::get_rank_and_dims(std::string path, size_t* dims)
     mda_header_unload(header);
 
     return rank;
+}
+
+//-----------------------------------------------------------------------------
+
+bool MDA_IO::generate_scaler_volume(std::string filename, data_struct::Params_Override* params_override, std::map<std::string, data_struct::ArrayXr>& scalers_map)
+{
+    /*
+    struct mda_file* mda_file = open_mda(filename);
+    if (mda_file == nullptr)
+    {
+        return false;
+    }
+
+    int mda_time_scaler_idx = -1;
+    real_t time_scaler_clock = 1.0;
+
+    bool single_row_scan = false;
+
+    Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> scaler_mat, abs_cfg_mat, H_dpc_cfg_mat, V_dpc_cfg_mat, dia1_dpc_cfg_mat, dia2_dpc_cfg_mat;
+
+    //don't save these scalers
+    std::list<std::string> ignore_scaler_strings = { "ELT1", "ERT1", "ICR1", "OCR1" };
+    std::list<struct scaler_struct> scalers;
+    std::list<data_struct::Summed_Scaler> summed_scalers;
+
+
+    for (int k = 0; k < mda_file->scan->sub_scans[0]->number_detectors; k++)
+    {
+        if (strcmp(mda_file->scan->sub_scans[0]->detectors[k]->name, det_name.c_str()) == 0)
+        {
+            val = mda_file->scan->sub_scans[0]->detectors_data[k][0];
+            units = std::string(mda_file->scan->sub_scans[0]->detectors[k]->unit);
+            return k;
+        }
+    }
+
+    real_t val;
+    std::string units;
+    bool save_cfg_abs = false;
+    if (params_override != nullptr && mda_file->scan->scan_rank > 1)
+    {
+        int us_ic_idx = -1;
+        int ds_ic_idx = -1;
+        int cfg_2_idx = -1;
+        int cfg_3_idx = -1;
+        int cfg_4_idx = -1;
+        int cfg_5_idx = -1;
+
+        int hdf_idx = 0;
+
+        if (params_override->time_scaler_clock.length() > 0)
+        {
+            time_scaler_clock = std::stod(params_override->time_scaler_clock);
+        }
+
+        for (auto itr : params_override->scaler_pvs)
+        {
+            //don't save ELT1, ERT1, ICR1, OCR1. these are saved elsewhere
+            std::list<std::string>::iterator s_itr = std::find(ignore_scaler_strings.begin(), ignore_scaler_strings.end(), itr.first);
+            if (s_itr != ignore_scaler_strings.end())
+                continue;
+
+            int mda_idx = find_scaler_index(mda_file, itr.second, val, units);
+            scalers.push_back(scaler_struct(itr.first, units, mda_idx, hdf_idx, false));
+            hdf_idx++;
+            std::string scaler_name = itr.first;
+            std::transform(scaler_name.begin(), scaler_name.end(), scaler_name.begin(), ::toupper);
+            if (mda_idx > -1)
+            {
+                if (scaler_name == "US_IC")
+                    us_ic_idx = mda_idx;
+                else if (scaler_name == "DS_IC")
+                    ds_ic_idx = mda_idx;
+                else if (scaler_name == "CFG_2")
+                    cfg_2_idx = mda_idx;
+                else if (scaler_name == "CFG_3")
+                    cfg_3_idx = mda_idx;
+                else if (scaler_name == "CFG_4")
+                    cfg_4_idx = mda_idx;
+                else if (scaler_name == "CFG_5")
+                    cfg_5_idx = mda_idx;
+            }
+        }
+        for (auto itr : params_override->time_normalized_scalers)
+        {
+            //don't save ELT1, ERT1, ICR1, OCR1. these are saved elsewhere
+            std::list<std::string>::iterator s_itr = std::find(ignore_scaler_strings.begin(), ignore_scaler_strings.end(), itr.first);
+            if (s_itr != ignore_scaler_strings.end())
+                continue;
+
+            std::string scaler_name = itr.first;
+            std::transform(scaler_name.begin(), scaler_name.end(), scaler_name.begin(), ::toupper);
+
+
+            int mda_idx = find_scaler_index(mda_file, itr.second, val, units);
+            if (mda_idx > -1)
+            {
+                bool found_scaler = false;
+                for (auto& subitr : scalers)
+                {
+                    if (subitr.hdf_name == itr.first)
+                    {
+                        subitr.mda_idx = mda_idx;
+                        subitr.normalize_by_time = true;
+                        subitr.hdf_units = units;
+                        found_scaler = true;
+                        break;
+                    }
+                }
+                if (found_scaler == false)
+                {
+                    scalers.push_back(scaler_struct(itr.first, units, mda_idx, hdf_idx, true));
+                    hdf_idx++;
+                }
+                if (scaler_name == "US_IC")
+                    us_ic_idx = mda_idx;
+                else if (scaler_name == "DS_IC")
+                    ds_ic_idx = mda_idx;
+                else if (scaler_name == "CFG_2")
+                    cfg_2_idx = mda_idx;
+                else if (scaler_name == "CFG_3")
+                    cfg_3_idx = mda_idx;
+                else if (scaler_name == "CFG_4")
+                    cfg_4_idx = mda_idx;
+                else if (scaler_name == "CFG_5")
+                    cfg_5_idx = mda_idx;
+            }
+        }
+
+        // Maps summed scaler name to scaler mda index
+        for (auto& itr : params_override->summed_scalers)
+        {
+            bool found = false;
+            for (auto& scaler_itr : itr.scalers_to_sum)
+            {
+                for (auto& found_scalers_itr : scalers)
+                {
+                    if (scaler_itr.first == found_scalers_itr.hdf_name && itr.normalize_by_time == found_scalers_itr.normalize_by_time)
+                    {
+                        scaler_itr.second = found_scalers_itr.mda_idx;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (found)
+            {
+                summed_scalers.push_back(itr);
+            }
+        }
+
+        //search for time scaler index
+        mda_time_scaler_idx = find_scaler_index(mda_scalers, params_override->time_scaler, val, units);
+
+        if (scalers.size() > 0)
+        {
+
+            if (mda_scalers->header->data_rank == 2)
+            {
+                if (hasNetcdf)
+                {
+                    count_3d[0] = 1;
+                    if (mda_scalers->scan->last_point == 0)
+                        count_3d[1] = 1;
+                    else
+                        count_3d[1] = mda_scalers->scan->last_point;
+                    if (mda_scalers->scan->sub_scans[0]->last_point == 0)
+                        count_3d[2] = 1;
+                    else
+                        count_3d[2] = mda_scalers->scan->sub_scans[0]->last_point;
+                }
+                else
+                {
+                    if (mda_scalers->header->dimensions[1] == 2000)
+                    {
+                        count_3d[0] = 1;
+                        count_3d[1] = 1;
+                        if (mda_scalers->scan->last_point == 0)
+                            count_3d[2] = 1;
+                        else
+                            count_3d[2] = mda_scalers->scan->last_point;
+                        single_row_scan = true;
+                    }
+                    else
+                    {
+                        logE << "Unknown or bad mda file" << "\n";
+                    }
+                }
+            }
+            else if (mda_scalers->header->data_rank == 3)
+            {
+                count_3d[0] = 1;
+                if (mda_scalers->scan->last_point == 0)
+                    count_3d[1] = 1;
+                else
+                    count_3d[1] = mda_scalers->scan->last_point;
+                if (mda_scalers->scan->sub_scans[0]->last_point == 0)
+                    count_3d[2] = 1;
+                else
+                    count_3d[2] = mda_scalers->scan->sub_scans[0]->last_point;
+            }
+            else
+            {
+                logE << "Unsupported rank " << mda_scalers->header->data_rank << " . Skipping scalers" << "\n";
+                return false;
+            }
+            
+
+            //save scalers
+            if (single_row_scan)
+            {
+                count_2d[0] = 1;
+                if (mda_scalers->scan->last_point == 0)
+                    count_2d[1] = 1;
+                else
+                    count_2d[1] = mda_scalers->scan->last_point;
+            }
+            else
+            {
+                if (mda_scalers->scan->last_point == 0)
+                    count_2d[0] = 1;
+                else
+                    count_2d[0] = mda_scalers->scan->last_point;
+                if (mda_scalers->scan->sub_scans[0]->last_point == 0)
+                    count_2d[1] = 1;
+                else
+                    count_2d[1] = mda_scalers->scan->sub_scans[0]->last_point;
+            }
+            count_3d[1] = count_2d[0];
+            count_3d[2] = count_2d[1];
+
+            scaler_mat.resize(count_2d[0], count_2d[1]);
+            scaler_mat.setZero(count_2d[0], count_2d[1]);
+
+            for (auto& itr : scalers)
+            {
+                scaler_mat.Zero(count_2d[0], count_2d[1]);
+
+                if (single_row_scan)
+                {
+                    for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
+                    {
+                        val = mda_scalers->scan->detectors_data[itr.mda_idx][i];
+                        if (itr.normalize_by_time && mda_time_scaler_idx > -1)
+                        {
+                            real_t scaler_time_normalizer = 1.0;
+                            real_t det_time = mda_scalers->scan->detectors_data[mda_time_scaler_idx][i];
+                            scaler_time_normalizer = det_time / time_scaler_clock;
+                            val /= scaler_time_normalizer;
+                        }
+                        if (std::isfinite(val))
+                        {
+                            scaler_mat(0, i) = val;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int32_t i = 0; i < mda_scalers->scan->last_point; i++)
+                    {
+                        for (int32_t j = 0; j < mda_scalers->scan->sub_scans[0]->last_point; j++)
+                        {
+                            val = mda_scalers->scan->sub_scans[i]->detectors_data[itr.mda_idx][j];
+                            if (itr.normalize_by_time && mda_time_scaler_idx > -1)
+                            {
+                                real_t scaler_time_normalizer = 1.0;
+                                real_t det_time = mda_scalers->scan->sub_scans[i]->detectors_data[mda_time_scaler_idx][j];
+                                scaler_time_normalizer = det_time / time_scaler_clock;
+                                val /= scaler_time_normalizer;
+                            }
+                            if (std::isfinite(val))
+                            {
+                                scaler_mat(i, j) = val;
+                            }
+                        }
+                    }
+                }
+            }
+
+
+        }
+    }
+    mda_unload(mda_file);
+    */
+    return true;
+}
+
+void MDA_IO::generate_extra_pvs_vector(std::string filename, std::vector<data_struct::Extra_PV> &extra_pvs)
+{
+
+    struct mda_file* mda_file = open_mda(filename);
+    if (mda_file == nullptr)
+    {
+        return;
+    }
+
+    for (int16_t i = 0; i < mda_file->extra->number_pvs; i++)
+    {
+        std::string str_val;
+        short* s_val;
+        int* i_val;
+        float* f_val;
+        double* d_val;
+
+        struct mda_pv* pv = mda_file->extra->pvs[i];
+        if (pv == nullptr)
+        {
+            continue;
+        }
+        data_struct::Extra_PV e_pv;
+        switch (pv->type)
+        {
+
+        case EXTRA_PV_STRING:
+            e_pv.value = std::string(pv->values);
+            break;
+            //case EXTRA_PV_INT8:
+
+            //    break;
+        case EXTRA_PV_INT16:
+            s_val = (short*)pv->values;
+            e_pv.value = std::to_string(*s_val);
+            break;
+        case EXTRA_PV_INT32:
+            i_val = (int*)pv->values;
+            e_pv.value = std::to_string(*i_val);
+            break;
+        case EXTRA_PV_FLOAT:
+            f_val = (float*)pv->values;
+            e_pv.value = std::to_string(*f_val);
+            break;
+        case EXTRA_PV_DOUBLE:
+            d_val = (double*)pv->values;
+            e_pv.value = std::to_string(*d_val);
+            break;
+
+        }
+
+        if (pv->name != nullptr)
+        {
+            e_pv.name = std::string(pv->name);
+        }
+
+        if (pv->description != nullptr)
+        {
+            e_pv.description = std::string(pv->description);
+        }
+
+        if (pv->unit != nullptr)
+        {
+            e_pv.unit = std::string(pv->unit);
+        }
+        extra_pvs.push_back(e_pv);
+    }
+
+    mda_unload(mda_file);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/io/file/mda_io.cpp
+++ b/src/io/file/mda_io.cpp
@@ -238,7 +238,7 @@ bool MDA_IO::_get_scaler_value( struct mda_file* _mda_file, data_struct::Params_
 
                         if(itr.normalize_by_time && found_time == true)
                         {
-                            if(find_scaler_index(_mda_file, override_values->time_normalized_scalers.at(itr2.first), tmp_val, units) > -1)
+                            if(find_scaler_index(_mda_file, override_values->time_normalized_scalers.at(itr2), tmp_val, units) > -1)
                             {
                                 tmp_val /= (time_scaler_val / time_scaler_clock);
                             }
@@ -279,7 +279,7 @@ bool MDA_IO::_get_scaler_value( struct mda_file* _mda_file, data_struct::Params_
                 {
                     tmp_val = 0;
 
-                    if(find_scaler_index(_mda_file, override_values->scaler_pvs.at(itr2.first), tmp_val, units) == -1)
+                    if(find_scaler_index(_mda_file, override_values->scaler_pvs.at(itr2), tmp_val, units) == -1)
                     {
                         tmp_val = 0;
                     }

--- a/src/io/file/mda_io.h
+++ b/src/io/file/mda_io.h
@@ -53,7 +53,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "data_struct/element_info.h"
 #include "data_struct/spectra_volume.h"
 #include "data_struct/quantification_standard.h"
-#include "data_struct/params_override.h"
+#include "data_struct/scan_info.h"
 #include "data_struct/analysis_job.h"
 
 namespace io
@@ -78,9 +78,9 @@ public:
      */
     ~MDA_IO();
 
-    void unload();
+    bool load(std::string path);
 
-    //struct mda_file* get_scan_ptr() { return _mda_file; }
+    bool load_header_only(std::string filePath);
 
     bool load_spectra_volume(std::string path,
                             size_t detector_num,
@@ -100,22 +100,26 @@ public:
     bool load_quantification_scalers(std::string path,
                                      data_struct::Params_Override *override_values);
 
-	// find index in mda file, if found, fill in value and units 
-    int find_scaler_index(struct mda_file* mda_file, std::string det_name, real_t& val, std::string &units);
 
-    int get_multiplied_dims(std::string path);
+    void unload();
+	
 
-    int get_rank_and_dims(std::string path, size_t* dims);
 
-    void search_and_update_amps(std::string path, data_struct::Params_Override* params_override);
+    void search_and_update_amps(std::string us_amp_pv_str, std::string ds_amp_pv_str, real_t& out_us_amp, real_t& out_ds_amp);
 
-    bool load_header(std::string filePath);
-
-    bool generate_scaler_volume(std::string filename, data_struct::Params_Override* params_override, std::map<std::string, data_struct::ArrayXr> &scalers_map);
-
-    void generate_extra_pvs_vector(std::string filename, std::vector<data_struct::Extra_PV>& extra_pvs);
+    data_struct::Scan_Info* get_scan_info() { return &_scan_info; }
 
 private:
+
+    void _load_scalers();
+
+    void _load_extra_pvs_vector();
+
+    void _load_meta_info();
+
+    // find index in mda file, if found, fill in value and units 
+    int find_scaler_index(struct mda_file* mda_file, std::string det_name, real_t& val, std::string& units);
+
 
     bool _get_scaler_value( struct mda_file* _mda_file, data_struct::Params_Override *override_values, string scaler_name, real_t *store_loc, bool isFlyScan);
 
@@ -133,9 +137,17 @@ private:
      */
     mda_fileinfo *_mda_file_info;
 
+    bool _hasNetcdf;
+
+    data_struct::Scan_Info _scan_info;
+
+    std::string _theta_pv_str;
 };
 
 DLL_EXPORT bool load_henke_from_xdr(std::string filename);
+DLL_EXPORT int mda_get_multiplied_dims(std::string path);
+DLL_EXPORT int mda_get_rank_and_dims(std::string path, size_t* dims);
+
 
 }// end namespace file
 }// end namespace io

--- a/src/io/file/mda_io.h
+++ b/src/io/file/mda_io.h
@@ -113,6 +113,8 @@ public:
 
     bool load_header(std::string filePath);
 
+    bool load_struct(std::string path);
+
 private:
 
     bool _get_scaler_value( struct mda_file* _mda_file, data_struct::Params_Override *override_values, string scaler_name, real_t *store_loc, bool isFlyScan);

--- a/src/io/file/mda_io.h
+++ b/src/io/file/mda_io.h
@@ -80,7 +80,7 @@ public:
 
     bool load(std::string path, data_struct::Params_Override* override_values);
 
-    bool load_header_only(std::string filePath);
+   // bool load_header_only(std::string filePath);
 
     bool load_spectra_volume(std::string path,
                             size_t detector_num,

--- a/src/io/file/mda_io.h
+++ b/src/io/file/mda_io.h
@@ -80,7 +80,7 @@ public:
 
     void unload();
 
-    struct mda_file* get_scan_ptr() { return _mda_file; }
+    //struct mda_file* get_scan_ptr() { return _mda_file; }
 
     bool load_spectra_volume(std::string path,
                             size_t detector_num,
@@ -92,6 +92,8 @@ public:
 										const std::vector<size_t>& detector_num_arr,
                                         bool hasNetCDF,
                                         data_struct::Analysis_Job *analysis_job,
+                                        size_t& out_rows,
+                                        size_t& out_cols,
 										data_struct::IO_Callback_Func_Def callback_func,
                                         void *user_data);
 
@@ -105,15 +107,13 @@ public:
 
     int get_rank_and_dims(std::string path, size_t* dims);
 
-    int rows() { return _rows; }
-
-    int cols() { return _cols; }
-
-    inline bool is_single_row_scan() {return _is_single_row;}
+    void search_and_update_amps(std::string path, data_struct::Params_Override* params_override);
 
     bool load_header(std::string filePath);
 
-    bool load_struct(std::string path);
+    bool generate_scaler_volume(std::string filename, data_struct::Params_Override* params_override, std::map<std::string, data_struct::ArrayXr> &scalers_map);
+
+    void generate_extra_pvs_vector(std::string filename, std::vector<data_struct::Extra_PV>& extra_pvs);
 
 private:
 
@@ -121,8 +121,7 @@ private:
 
     bool _find_theta(std::string pv_name, float* theta_out);
 
-    //void _load_detector_meta_data(data_struct::Detector * detector);
-    bool _is_single_row;
+    //bool _is_single_row;
 
     /**
      * @brief _mda_file: mda helper structure
@@ -133,10 +132,6 @@ private:
      * @brief _mda_file_info: lazy load struct
      */
     mda_fileinfo *_mda_file_info;
-
-    int _rows;
-
-    int _cols;
 
 };
 

--- a/src/io/file/mda_io.h
+++ b/src/io/file/mda_io.h
@@ -78,7 +78,7 @@ public:
      */
     ~MDA_IO();
 
-    bool load(std::string path);
+    bool load(std::string path, data_struct::Params_Override* override_values);
 
     bool load_header_only(std::string filePath);
 
@@ -99,7 +99,6 @@ public:
 
     bool load_quantification_scalers(std::string path,
                                      data_struct::Params_Override *override_values);
-
 
     void unload();
 	

--- a/src/pybindings/main.cpp
+++ b/src/pybindings/main.cpp
@@ -380,9 +380,9 @@ PYBIND11_MODULE(pyxrfmaps, m) {
     .def("unload", &io::file::MDA_IO::unload)
     .def("load_spectra_volume", &io::file::MDA_IO::load_spectra_volume)
     .def("load_spectra_volume_with_callback", &io::file::MDA_IO::load_spectra_volume_with_callback)
-    .def("find_scaler_index", &io::file::MDA_IO::find_scaler_index)
-    .def("get_multiplied_dims", &io::file::MDA_IO::get_multiplied_dims)
-    .def("get_rank_and_dims", &io::file::MDA_IO::get_rank_and_dims);
+    //.def("find_scaler_index", &io::file::MDA_IO::find_scaler_index)
+    .def("get_multiplied_dims", &io::file::mda_get_multiplied_dims)
+    .def("get_rank_and_dims", &io::file::mda_get_rank_and_dims);
 
     //NetCDF_IO
     io_file.def("netcdf_load_spectra_line", [](std::string path,

--- a/src/pybindings/main.cpp
+++ b/src/pybindings/main.cpp
@@ -382,10 +382,7 @@ PYBIND11_MODULE(pyxrfmaps, m) {
     .def("load_spectra_volume_with_callback", &io::file::MDA_IO::load_spectra_volume_with_callback)
     .def("find_scaler_index", &io::file::MDA_IO::find_scaler_index)
     .def("get_multiplied_dims", &io::file::MDA_IO::get_multiplied_dims)
-    .def("get_rank_and_dims", &io::file::MDA_IO::get_rank_and_dims)
-    .def("rows", &io::file::MDA_IO::rows)
-    .def("cols", &io::file::MDA_IO::cols)
-    .def("is_single_row_scan", &io::file::MDA_IO::is_single_row_scan);
+    .def("get_rank_and_dims", &io::file::MDA_IO::get_rank_and_dims);
 
     //NetCDF_IO
     io_file.def("netcdf_load_spectra_line", [](std::string path,

--- a/src/workflow/xrf/spectra_file_source.cpp
+++ b/src/workflow/xrf/spectra_file_source.cpp
@@ -278,7 +278,8 @@ bool Spectra_File_Source::_load_spectra_volume_with_callback(std::string dataset
     //    continue;
     //}
 
-
+    size_t row_size = 0;
+    size_t col_size = 0;
     _current_dataset_directory = new std::string(dataset_directory);
     _current_dataset_name = new std::string(dataset_file);
     //load spectra
@@ -286,6 +287,8 @@ bool Spectra_File_Source::_load_spectra_volume_with_callback(std::string dataset
                                                         detector_num_arr,
                                                         hasNetcdf | hasBnpNetcdf | hasHdf,
                                                         _analysis_job,
+                                                        row_size,
+                                                        col_size,
                                                         callback_fun,
                                                         nullptr) )
     {
@@ -303,8 +306,6 @@ bool Spectra_File_Source::_load_spectra_volume_with_callback(std::string dataset
             {
                 file_io.close();
                 std::string full_filename;
-                int row_size = mda_io.rows();
-                int col_size = mda_io.cols();
                 for(int i=0; i<row_size; i++)
                 {
                     full_filename = dataset_directory + "flyXRF"+ DIR_END_CHAR + tmp_dataset_file + file_middle + std::to_string(i) + ".nc";
@@ -326,8 +327,6 @@ bool Spectra_File_Source::_load_spectra_volume_with_callback(std::string dataset
             {
                 file_io.close();
                 std::string full_filename;
-                int row_size = mda_io.rows();
-                int col_size = mda_io.cols();
                 for(int i=0; i<row_size; i++)
                 {
                     std::string row_idx_str = std::to_string(i+1);

--- a/test/Test_2_ID_E.py
+++ b/test/Test_2_ID_E.py
@@ -2,12 +2,18 @@
 #Don't forget to append XRF-Maps/bin directory to PYTHONPATH
 
 import pyxrfmaps as px
+import os
+
+if os.name == 'nt':
+    os_end_char = '\\'
+else:
+    os_end_char = '/'
 
 element_csv_filename = "../reference/xrf_library.csv"
 element_henke_filename = "../reference/henke.xdr"
 
 def load_spectra_vol_and_print():
-	dataset_dir = '2_ID_E_dataset/'
+	dataset_dir = '2_ID_E_dataset' + os_end_char
 	dataset_file = 'axo_std.mda'
 	detector_num = 0
 	sv = px.Spectra_Volume()
@@ -24,11 +30,10 @@ def load_spectra_vol_and_print():
 def run_analysis():
     px.load_element_info(element_henke_filename, element_csv_filename)
     job = px.AnalysisJob()
-    job.dataset_directory = '2_ID_E_dataset/'
+    job.dataset_directory = '2_ID_E_dataset' + os_end_char
     job.dataset_files = px.find_all_dataset_files(job.dataset_directory + "mda/", ".mda")
     job.optimize_dataset_files = job.dataset_files
-    job.detector_num_start = 0
-    job.detector_num_end = 3
+    job.detector_num_arr = [0,1,2,3]
     job.quick_and_dirty = False
     job.fitting_routines = [px.FittingRoutines.ROI, px.FittingRoutines.SVD, px.FittingRoutines.MATRIX, px.FittingRoutines.NNLS]
     job.quantification_standard_filename = 'maps_standardinfo.txt'


### PR DESCRIPTION
-Updated it so all scalers are saved from mda file and can later be renamed if their labels were missing during processing.
-Fixed bug not using bracning family parameter in override file.
-Added --export-csv parameter to save integrated spec, fitted spec, background to csv
-Added fitted_integrated_spectra for nnls
-Added save fitted_integrated_background for matrix fitting
-Added save function for override parameters used in uProbeX
