### PR TITLE
Reverted us_ic and ds_ic to caps

### DIFF
--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -185,9 +185,8 @@ const string STR_FIT_GAUSS_MATRIX = "Fitted";
 const string STR_FIT_GAUSS_TAILS = "gaussian_parameter";
 
 const string STR_SR_CURRENT = "SR_Current";
-const string STR_US_IC = "us_ic";
-const string STR_DS_IC = "ds_ic";
-
+const string STR_US_IC = "US_IC";
+const string STR_DS_IC = "DS_IC";
 
 const string STR_K_A_LINES = "K Alpha";
 const string STR_K_B_LINES = "K Beta";


### PR DESCRIPTION
Update v9 layout /MAPS/make_maps_conf/element_standard to /MAPS/make_maps_conf/nbs1832 to be viewable in IDL MAPS. Changed US_IC and DS_IC to lower case us_ic ds_ic for IDL Maps